### PR TITLE
Do not try to generate documentation when the required apiDocPath option is missing

### DIFF
--- a/src/bin/jester-batch.js
+++ b/src/bin/jester-batch.js
@@ -11,7 +11,11 @@ var config = loadConfig("./jester.json");
 
 rebuildProject(config.fullEntryGlob, config.artifactPath)
     .then(function() {
-        return rebuildDocumentation(config.srcPath, config.apiDocPath, config.jsdocConf, config.readme);
+        if(config.srcPath && config.apiDocPath) {
+            return rebuildDocumentation(config.srcPath, config.apiDocPath, config.jsdocConf, config.readme);
+        } else {
+            console.log("please configure srcPath and apiDocPath in order to generate jsdoc documentation")
+        }
     })
     .then(function() {
         return runAllTests(config);

--- a/src/bin/jester-batch.js
+++ b/src/bin/jester-batch.js
@@ -26,7 +26,7 @@ rebuildProject(config.fullEntryGlob, config.artifactPath)
         },
         function(err) {
             console.log(err);
-            if(error.stack) {
+            if(err.stack) {
                 console.log(err.stack);
             }
             process.exit(1);

--- a/src/lib/rebuildDocumentation.js
+++ b/src/lib/rebuildDocumentation.js
@@ -1,33 +1,31 @@
 var child_process = require("child_process"),
     p = require("path"),
     fs = require("fs"),
-    when = require("when"),
     whenNode = require("when/node");
 
 module.exports = function rebuildDocumentation(srcPath, targetPath, confPath, readmePath) {
-
-    var toAbsolutePath = function(path) {
-        if(path) {
-            var absolutePath = p.resolve(path);
-            if (fs.existsSync(absolutePath)) {
-                return absolutePath;
-            }
-        }
-        return "";
+    var pathExists = function(path) {
+        return path && fs.existsSync(path);
     };
 
-    var src = toAbsolutePath(srcPath);
-    var target = "-d " + p.resolve(targetPath);
-    var readme = toAbsolutePath(readmePath);
-    var options = "-r";
-    var conf = toAbsolutePath(confPath);
-    if (conf) {
-        conf = "-c " + conf;
-    }
+    var ensurePathExists = function(path, msg) {
+        if(!pathExists(path)) {
+            throw new Error(msg ? msg : "path does not exist: " + path);
+        }
+    };
 
-    var node = "node";
+    ensurePathExists(srcPath);
+    ensurePathExists(targetPath, "you must define a valid documentation directory by setting apiDocPath in jester.json");
+
+    // define command line options:
+    var options = "-r";
+    var src = p.resolve(srcPath);
+    var target = "-d " + p.resolve(targetPath);
+    var readme = pathExists(readmePath) ? p.resolve(readmePath) : "";
+    var conf = pathExists(confPath) ? "-c " + p.resolve(confPath) : "";
+
     var jsdoc = require.resolve("jsdoc/jsdoc");
-    var cmd = [node, jsdoc, readme, src, options, target, conf].join(" ");
+    var cmd = ["node", jsdoc, readme, src, options, target, conf].join(" ");
 
     var exec = whenNode.lift(child_process.exec);
 

--- a/src/lib/rebuildDocumentation.js
+++ b/src/lib/rebuildDocumentation.js
@@ -7,16 +7,16 @@ var child_process = require("child_process"),
 module.exports = function rebuildDocumentation(srcPath, targetPath, confPath, readmePath) {
 
     var toAbsolutePath = function(path) {
-        var absolutePath = p.resolve(path);
-        if(fs.existsSync(absolutePath)) {
-            return absolutePath;
+        if(path) {
+            var absolutePath = p.resolve(path);
+            if (fs.existsSync(absolutePath)) {
+                return absolutePath;
+            }
         }
-        else {
-            return "";
-        }
+        return "";
     };
 
-    var src = p.resolve(srcPath);
+    var src = toAbsolutePath(srcPath);
     var target = "-d " + p.resolve(targetPath);
     var readme = toAbsolutePath(readmePath);
     var options = "-r";


### PR DESCRIPTION
I don't feel comfortable just dumping the docs in some directory, so srcPath and apiDocPath are both required and jester will just skip generating documentation when thery are missing.

Also improved:
- fixes typo in jester-batch
- check for srcPath existence in rebuildDocumentation
- do not try to use a falsy path var in rebuildDocumentation
