### PR TITLE
Jsdoc

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -169,29 +169,43 @@
       }
     },
     "jsdoc": {
-      "version": "3.3.0-alpha5",
-      "from": "jsdoc@3.3.0-alpha5",
+      "version": "3.3.0-alpha8",
+      "from": "jsdoc@3.3.0-alpha8",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@0.1.22",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+          "from": "async@~0.1.22"
         },
         "catharsis": {
-          "version": "0.7.1",
-          "from": "catharsis@0.7.1"
+          "version": "0.8.2",
+          "from": "catharsis@~0.8.2",
+          "dependencies": {
+            "underscore-contrib": {
+              "version": "0.3.0",
+              "from": "underscore-contrib@~0.3.0"
+            }
+          }
         },
         "esprima": {
-          "version": "1.0.4",
-          "from": "esprima@1.0.4"
+          "version": "1.1.0-dev-harmony",
+          "from": "https://github.com/ariya/esprima/tarball/49a2eccb243f29bd653b11e9419241a9d726af7c",
+          "resolved": "https://github.com/ariya/esprima/tarball/49a2eccb243f29bd653b11e9419241a9d726af7c"
         },
         "js2xmlparser": {
           "version": "0.1.3",
-          "from": "js2xmlparser@0.1.3"
+          "from": "js2xmlparser@~0.1.0"
         },
         "marked": {
           "version": "0.3.2",
-          "from": "marked@0.3.2"
+          "from": "marked@~0.3.1"
+        },
+        "requizzle": {
+          "version": "0.1.1",
+          "from": "requizzle@~0.1.1"
+        },
+        "strip-json-comments": {
+          "version": "0.1.3",
+          "from": "strip-json-comments@~0.1.3"
         },
         "taffydb": {
           "version": "2.6.2",
@@ -199,13 +213,12 @@
           "resolved": "https://github.com/hegemonic/taffydb/tarball/master"
         },
         "underscore": {
-          "version": "1.4.4",
-          "from": "underscore@1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+          "version": "1.6.0",
+          "from": "underscore@~1.6.0"
         },
         "wrench": {
           "version": "1.3.9",
-          "from": "wrench@1.3.9"
+          "from": "wrench@~1.3.9"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-path-formatter": "0.1.1",
     "source-map-support": "~0.2.5",
     "json-loader": "~0.5.0",
-    "jsdoc": "~3.3.0",
+    "jsdoc": "3.3.0-alpha8",
     "when": "~3.1.0"
   }
 }


### PR DESCRIPTION
Updated jsdoc to 3.3.0-alpha8
-  3.3.0-alpha8 and higher does not need admin rights to install on windows.
-  3.3.0-alpha8 and lower won't break on empty jsdoc tag.
