### PR TITLE
Re-add lines to serve source map support to karma server config

### DIFF
--- a/src/lib/karmaServer.js
+++ b/src/lib/karmaServer.js
@@ -13,7 +13,10 @@ function KarmaServer(karmaPath, options) {
         basePath: karmaPath,
         frameworks: ["jasmine"].concat(options.frameworks || []),
         files: [
-          "*.js"
+            {pattern: require.resolve("source-map-support/browser-source-map-support"), watched: false, included: true},
+            {pattern: require.resolve("./loadSourcemapsupport"), watched: false, included: true},
+            {pattern: '*.js.map', watched: false, included: false, served: true},
+            "*.js"
         ],
         proxies: options.proxies || {},
         preprocessors: options.preprocessors || {},


### PR DESCRIPTION
Om te testen:

vóór deze PR:
1. Maak een unittest die een error gooit
2. voer de unittest uit in een debug browser:
   1. Druk in een browser op de debug knop
   2. open de console, druk op de knop pause on errors inclusief pause on caught errors
   3. ververs de pagina zodat de tests opnieuw worden uitgevoerd
3. Merk op hoe je niet in de file van de unittest zit maar in een file met allemaal extra meuk
4. druk op play
5. Merk op dat de error in de browser console niet de correcte regel noemt.

Na deze PR

Doe hetzelfde, maar merk nu op dat het lijkt alsof de error wel door de originele file gegooit wordt en dat de error in de browser console wel de correcte regel noemt. De errors in de shell console verwijzen overigens nog steeds naar de verkeerde regel. Can't be helped
