### PR TITLE
New release

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,8 @@
     "no-console": 0,
     "no-unused-vars": [2, {"vars": "all", "args": "none"}],
     "quotes": 0,
-    "no-use-before-define": [2, "nofunc"]
+    "no-use-before-define": [2, "nofunc"],
     "no-empty": 2, //empty catches are allowed, other empty blocks should be avoided
+    "no-multi-str": 0
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,39 @@
+{
+  "env": {
+    "node": true
+  },
+  "rules": {
+    //For IE8:
+    //"no-comma-dangle": 2,
+    "no-comma-dangle": 0,
+    "no-reserved-keys": 0,
+    "no-cond-assign": [2, "except-parens"], //disallow `if (foo = 2)` do allow `if ((foo = 2))` and `if ((foo = bar) === 2)`
+    //regex errors
+    "no-control-regex": 2, //probably a mistake in using the \ character in your regex
+    "no-empty-class": 2,
+    "no-dupe-keys": 2,
+    "no-invalid-regexp": 2,
+    //semi-colon styling
+    "no-extra-semi": 2,
+    "semi": [2, "always"],
+    "no-space-before-semi": 2,
+    //assignment errors
+    "no-func-assign": 2, //don't assign to the implicit variable created by defining a function
+    "no-inner-declarations": [2, "functions"], //don't declare a function inside a block (is an error in strict mode)
+    "no-irregular-whitespace": 2,
+    "no-negated-in-lhs": 2,
+    "no-sparse-arrays": 2,
+    "no-unreachable": 2,
+    "use-isnan": 2,
+    "valid-jsdoc": 2,
+    "valid-typeof": 2,
+    "strict": [2, "global"],
+    "global-strict": 0,//needs to be disabled explicitly until removed in 1.0
+    "consistent-return": 2,
+    "no-console": 0,
+    "no-unused-vars": [2, {"vars": "all", "args": "none"}],
+    "quotes": 0,
+    "no-use-before-define": [2, "nofunc"]
+    "no-empty": 2, //empty catches are allowed, other empty blocks should be avoided
+  }
+}

--- a/jester.json
+++ b/jester.json
@@ -6,7 +6,6 @@
     "readme": "./readme.md",
     "entryGlob": "app/features/*/feature.js",
     "karmaPath": "./build/karma/",
-    "artifactPath": "./build/artifacts",
     "karmaOptions": {
         "proxies": {},
         "browsers": [

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "jester-tester",
-  "version": "3.0.0-alpha2",
+  "version": "3.0.0-alpha8",
   "npm-shrinkwrap-version": "5.1.0",
   "dependencies": {
     "deepmerge": {
@@ -8,40 +8,44 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-0.2.7.tgz"
     },
     "eslint": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.13.0.tgz",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.17.1.tgz",
       "dependencies": {
         "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
             },
             "has-ansi": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
         },
@@ -78,32 +82,36 @@
           }
         },
         "debug": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
           "dependencies": {
             "ms": {
-              "version": "0.6.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
             }
           }
         },
         "doctrine": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.2.tgz",
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
           "dependencies": {
             "esutils": {
               "version": "1.1.6",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
         "escape-string-regexp": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
         "escope": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-2.0.3.tgz",
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-2.0.6.tgz",
           "dependencies": {
             "es6-map": {
               "version": "0.1.1",
@@ -114,12 +122,24 @@
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
-                  "version": "0.10.5",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.5.tgz"
+                  "version": "0.10.6",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
                 },
                 "es6-iterator": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
                 },
                 "es6-set": {
                   "version": "0.1.1",
@@ -144,12 +164,24 @@
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
-                  "version": "0.10.5",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.5.tgz"
+                  "version": "0.10.6",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
                 },
                 "es6-iterator": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
                 },
                 "es6-symbol": {
                   "version": "0.1.1",
@@ -168,48 +200,48 @@
           }
         },
         "espree": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-1.7.1.tgz"
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-1.12.2.tgz"
         },
         "estraverse": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
         },
         "estraverse-fb": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.0.tgz"
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
         },
         "globals": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-5.1.0.tgz"
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
         },
         "js-yaml": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.5.tgz",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
           "dependencies": {
             "argparse": {
-              "version": "0.1.16",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
               "dependencies": {
-                "underscore": {
-                  "version": "1.7.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                "lodash": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
                 },
-                "underscore.string": {
-                  "version": "2.4.0",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                "sprintf-js": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                 }
               }
             },
             "esprima": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
             }
           }
         },
         "minimatch": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,143 +1,133 @@
 {
   "name": "jester-tester",
-  "version": "1.1.0",
+  "version": "2.0.0",
+  "npm-shrinkwrap-version": "5.1.0",
   "dependencies": {
     "eslint": {
       "version": "0.4.2",
-      "from": "https://registry.npmjs.org/eslint/-/eslint-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.4.2.tgz",
       "dependencies": {
-        "optionator": {
-          "version": "0.1.1",
-          "from": "optionator@0.1.1",
-          "dependencies": {
-            "prelude-ls": {
-              "version": "1.0.3",
-              "from": "prelude-ls@1.0.3"
-            },
-            "deep-is": {
-              "version": "0.1.2",
-              "from": "deep-is@0.1.2"
-            },
-            "wordwrap": {
-              "version": "0.0.2",
-              "from": "wordwrap@0.0.2"
-            },
-            "type-check": {
-              "version": "0.3.1",
-              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
-                }
-              }
-            },
-            "levn": {
-              "version": "0.2.5",
-              "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
-                }
-              }
-            },
-            "levenshtein-damerau": {
-              "version": "0.1.0-2",
-              "from": "levenshtein-damerau@0.1.0-2"
-            }
-          }
-        },
-        "estraverse": {
-          "version": "1.3.2",
-          "from": "estraverse@1.3.2"
-        },
-        "esprima": {
-          "version": "1.2.2",
-          "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
-        },
-        "escope": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/escope/-/escope-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-1.0.0.tgz"
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@0.2.0"
-        },
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
-            "has-color": {
-              "version": "0.1.7",
-              "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
-            },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@1.0.0"
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+            },
+            "has-color": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@0.1.1"
-            }
-          }
-        },
-        "strip-json-comments": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.2.tgz"
-        },
-        "js-yaml": {
-          "version": "3.0.2",
-          "from": "js-yaml@3.0.2",
-          "dependencies": {
-            "argparse": {
-              "version": "0.1.15",
-              "from": "argparse@0.1.15",
-              "dependencies": {
-                "underscore": {
-                  "version": "1.4.4",
-                  "from": "underscore@1.4.4",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
-                },
-                "underscore.string": {
-                  "version": "2.3.3",
-                  "from": "underscore.string@2.3.3"
-                }
-              }
-            },
-            "esprima": {
-              "version": "1.0.4",
-              "from": "esprima@1.0.4"
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "doctrine": {
           "version": "0.3.0",
-          "from": "doctrine@0.3.0"
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.3.0.tgz"
+        },
+        "escope": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-1.0.0.tgz"
+        },
+        "esprima": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.3.tgz"
+        },
+        "estraverse": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
+        },
+        "js-yaml": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "optionator": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.1.1.tgz",
+          "dependencies": {
+            "deep-is": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+            },
+            "levenshtein-damerau": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/levenshtein-damerau/-/levenshtein-damerau-0.1.0.tgz"
+            },
+            "levn": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                }
+              }
+            },
+            "prelude-ls": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.0.3.tgz"
+            },
+            "type-check": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                }
+              }
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "eslint-path-formatter": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/eslint-path-formatter/-/eslint-path-formatter-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint-path-formatter/-/eslint-path-formatter-0.1.1.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.1.33",
-          "from": "source-map@0.1.33",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",
-              "from": "amdefine@0.1.0"
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
         }
@@ -145,417 +135,383 @@
     },
     "glob": {
       "version": "3.2.8",
-      "from": "https://registry.npmjs.org/glob/-/glob-3.2.8.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.8.tgz",
       "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2.5.0"
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@1.0.0"
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "from": "inherits@2.0.1"
         }
       }
     },
     "jsdoc": {
       "version": "3.3.0-alpha8",
-      "from": "jsdoc@3.3.0-alpha8",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.3.0-alpha8.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22"
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "catharsis": {
           "version": "0.8.2",
-          "from": "catharsis@~0.8.2",
+          "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.2.tgz",
           "dependencies": {
             "underscore-contrib": {
               "version": "0.3.0",
-              "from": "underscore-contrib@~0.3.0"
+              "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz"
             }
           }
         },
         "esprima": {
           "version": "1.1.0-dev-harmony",
-          "from": "https://github.com/ariya/esprima/tarball/49a2eccb243f29bd653b11e9419241a9d726af7c",
+          "from": "esprima@https://github.com/ariya/esprima/tarball/49a2eccb243f29bd653b11e9419241a9d726af7c",
           "resolved": "https://github.com/ariya/esprima/tarball/49a2eccb243f29bd653b11e9419241a9d726af7c"
         },
         "js2xmlparser": {
           "version": "0.1.3",
-          "from": "js2xmlparser@~0.1.0"
+          "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-0.1.3.tgz"
         },
         "marked": {
           "version": "0.3.2",
-          "from": "marked@~0.3.1"
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.2.tgz"
         },
         "requizzle": {
           "version": "0.1.1",
-          "from": "requizzle@~0.1.1"
+          "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.1.1.tgz"
         },
         "strip-json-comments": {
           "version": "0.1.3",
-          "from": "strip-json-comments@~0.1.3"
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
         },
         "taffydb": {
           "version": "2.6.2",
-          "from": "https://github.com/hegemonic/taffydb/tarball/master",
+          "from": "taffydb@https://github.com/hegemonic/taffydb/tarball/master",
           "resolved": "https://github.com/hegemonic/taffydb/tarball/master"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@~1.6.0"
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         },
         "wrench": {
           "version": "1.3.9",
-          "from": "wrench@~1.3.9"
+          "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz"
         }
       }
     },
     "json-loader": {
       "version": "0.5.0",
-      "from": "json-loader@0.5.0"
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.0.tgz"
     },
     "karma": {
       "version": "0.12.13",
-      "from": "https://registry.npmjs.org/karma/-/karma-0.12.13.tgz",
       "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.13.tgz",
       "dependencies": {
-        "di": {
-          "version": "0.0.1",
-          "from": "di@0.0.1"
-        },
-        "socket.io": {
-          "version": "0.9.16",
-          "from": "socket.io@0.9.16",
-          "dependencies": {
-            "socket.io-client": {
-              "version": "0.9.16",
-              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
-              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
-              "dependencies": {
-                "uglify-js": {
-                  "version": "1.2.5",
-                  "from": "uglify-js@1.2.5"
-                },
-                "ws": {
-                  "version": "0.4.31",
-                  "from": "ws@0.4.31",
-                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
-                  "dependencies": {
-                    "commander": {
-                      "version": "0.6.1",
-                      "from": "commander@0.6.1",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-                    },
-                    "nan": {
-                      "version": "0.3.2",
-                      "from": "nan@0.3.2"
-                    },
-                    "tinycolor": {
-                      "version": "0.0.1",
-                      "from": "tinycolor@0.0.1"
-                    },
-                    "options": {
-                      "version": "0.0.5",
-                      "from": "options@0.0.5"
-                    }
-                  }
-                },
-                "xmlhttprequest": {
-                  "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
-                },
-                "active-x-obfuscator": {
-                  "version": "0.0.1",
-                  "from": "active-x-obfuscator@0.0.1",
-                  "dependencies": {
-                    "zeparser": {
-                      "version": "0.0.5",
-                      "from": "zeparser@0.0.5"
-                    }
-                  }
-                }
-              }
-            },
-            "policyfile": {
-              "version": "0.0.4",
-              "from": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
-            },
-            "base64id": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
-            },
-            "redis": {
-              "version": "0.7.3",
-              "from": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
-              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
-            }
-          }
-        },
         "chokidar": {
           "version": "0.8.2",
-          "from": "chokidar@0.8.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.8.2.tgz",
           "dependencies": {
             "recursive-readdir": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-0.0.2.tgz"
             }
           }
         },
-        "minimatch": {
-          "version": "0.2.14",
-          "from": "minimatch@0.2.14",
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "connect": {
+          "version": "2.12.0",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.12.0.tgz",
           "dependencies": {
-            "lru-cache": {
-              "version": "2.5.0",
-              "from": "lru-cache@2.5.0"
+            "batch": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz"
             },
-            "sigmund": {
-              "version": "1.0.0",
-              "from": "sigmund@1.0.0"
+            "buffer-crc32": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+            },
+            "bytes": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz"
+            },
+            "cookie": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz"
+            },
+            "debug": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
+            },
+            "fresh": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz"
+            },
+            "methods": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz"
+            },
+            "multiparty": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13-1",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.25-1",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                    }
+                  }
+                },
+                "stream-counter": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
+                }
+              }
+            },
+            "negotiator": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
+            },
+            "pause": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+            },
+            "qs": {
+              "version": "0.6.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+            },
+            "raw-body": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.2.tgz"
+            },
+            "send": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
+              "dependencies": {
+                "range-parser": {
+                  "version": "0.0.4",
+                  "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz"
+                }
+              }
+            },
+            "uid2": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
             }
           }
         },
+        "di": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
+        },
+        "graceful-fs": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+        },
         "http-proxy": {
           "version": "0.10.4",
-          "from": "http-proxy@0.10.4",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
           "dependencies": {
             "pkginfo": {
               "version": "0.3.0",
-              "from": "pkginfo@0.3.0"
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "utile": {
               "version": "0.2.1",
-              "from": "utile@0.2.1",
+              "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@0.2.10",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "deep-equal": {
                   "version": "0.2.1",
-                  "from": "deep-equal@0.2.1"
+                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
                 },
                 "i": {
                   "version": "0.3.2",
-                  "from": "i@0.3.2"
+                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
                 },
                 "ncp": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                 }
               }
             }
           }
         },
-        "optimist": {
-          "version": "0.6.1",
-          "from": "optimist@0.6.1",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "from": "wordwrap@0.0.2"
-            },
-            "minimist": {
-              "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            }
-          }
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-        },
-        "q": {
-          "version": "0.9.7",
-          "from": "q@0.9.7"
-        },
-        "colors": {
-          "version": "0.6.2",
-          "from": "colors@0.6.2"
-        },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@2.4.1"
-        },
-        "mime": {
-          "version": "1.2.11",
-          "from": "mime@1.2.11"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "log4js": {
           "version": "0.6.14",
-          "from": "log4js@0.6.14",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.14.tgz",
           "dependencies": {
             "async": {
               "version": "0.1.15",
-              "from": "async@0.1.15",
               "resolved": "https://registry.npmjs.org/async/-/async-0.1.15.tgz"
-            },
-            "semver": {
-              "version": "1.1.4",
-              "from": "semver@1.1.4"
             },
             "readable-stream": {
               "version": "1.0.27-1",
-              "from": "readable-stream@1.0.27-1",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@1.0.1"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.25-1",
-                  "from": "string_decoder@0.10.25-1"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2.0.1"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                 }
               }
+            },
+            "semver": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
             }
           }
         },
-        "useragent": {
-          "version": "2.0.8",
-          "from": "useragent@2.0.8",
+        "mime": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.2.4",
-              "from": "lru-cache@2.2.4"
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
-        "graceful-fs": {
-          "version": "2.0.3",
-          "from": "graceful-fs@2.0.3"
-        },
-        "connect": {
-          "version": "2.12.0",
-          "from": "connect@2.12.0",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-2.12.0.tgz",
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
-            "batch": {
-              "version": "0.5.0",
-              "from": "batch@0.5.0"
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             },
-            "qs": {
-              "version": "0.6.6",
-              "from": "qs@0.6.6"
-            },
-            "cookie-signature": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz"
-            },
-            "buffer-crc32": {
-              "version": "0.2.1",
-              "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
-            },
-            "cookie": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            }
+          }
+        },
+        "q": {
+          "version": "0.9.7",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        },
+        "socket.io": {
+          "version": "0.9.16",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
+          "dependencies": {
+            "base64id": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
-            "send": {
-              "version": "0.1.4",
-              "from": "send@0.1.4",
+            "policyfile": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
+            },
+            "redis": {
+              "version": "0.7.3",
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
+            },
+            "socket.io-client": {
+              "version": "0.9.16",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
-                "range-parser": {
-                  "version": "0.0.4",
-                  "from": "range-parser@0.0.4"
-                }
-              }
-            },
-            "bytes": {
-              "version": "0.2.1",
-              "from": "bytes@0.2.1"
-            },
-            "fresh": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz"
-            },
-            "pause": {
-              "version": "0.0.1",
-              "from": "pause@0.0.1"
-            },
-            "uid2": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
-            },
-            "debug": {
-              "version": "0.8.1",
-              "from": "debug@0.8.1"
-            },
-            "methods": {
-              "version": "0.1.0",
-              "from": "methods@0.1.0"
-            },
-            "raw-body": {
-              "version": "1.1.2",
-              "from": "raw-body@1.1.2"
-            },
-            "negotiator": {
-              "version": "0.3.0",
-              "from": "negotiator@0.3.0"
-            },
-            "multiparty": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13-1",
-                  "from": "readable-stream@1.1.13-1",
+                "active-x-obfuscator": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@1.0.1"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.25-1",
-                      "from": "string_decoder@0.10.25-1"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2.0.1"
+                    "zeparser": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
                     }
                   }
                 },
-                "stream-counter": {
-                  "version": "0.2.0",
-                  "from": "stream-counter@0.2.0"
+                "uglify-js": {
+                  "version": "1.2.5",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
+                },
+                "ws": {
+                  "version": "0.4.31",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "0.6.1",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                    },
+                    "nan": {
+                      "version": "0.3.2",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                    },
+                    "options": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.5.tgz"
+                    },
+                    "tinycolor": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                    }
+                  }
+                },
+                "xmlhttprequest": {
+                  "version": "1.4.2",
+                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
                 }
               }
             }
@@ -563,11 +519,21 @@
         },
         "source-map": {
           "version": "0.1.33",
-          "from": "source-map@0.1.33",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",
-              "from": "amdefine@0.1.0"
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        },
+        "useragent": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.8.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.2.4",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
             }
           }
         }
@@ -575,242 +541,225 @@
     },
     "karma-chrome-launcher": {
       "version": "0.1.2",
-      "from": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.2.tgz"
     },
     "karma-firefox-launcher": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-0.1.3.tgz"
     },
     "karma-ie-launcher": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/karma-ie-launcher/-/karma-ie-launcher-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/karma-ie-launcher/-/karma-ie-launcher-0.1.3.tgz"
     },
     "karma-jasmine": {
       "version": "0.2.2",
-      "from": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.2.2.tgz"
     },
     "karma-junit-reporter": {
       "version": "0.2.1",
-      "from": "https://registry.npmjs.org/karma-junit-reporter/-/karma-junit-reporter-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/karma-junit-reporter/-/karma-junit-reporter-0.2.1.tgz",
       "dependencies": {
         "xmlbuilder": {
           "version": "0.4.2",
-          "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
         }
       }
     },
     "karma-phantomjs-launcher": {
       "version": "0.1.2",
-      "from": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.2.tgz",
       "dependencies": {
         "phantomjs": {
           "version": "1.9.7-14",
-          "from": "phantomjs@~1.9",
           "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.7-14.tgz",
           "dependencies": {
             "adm-zip": {
               "version": "0.2.1",
-              "from": "adm-zip@0.2.1",
               "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.2.1.tgz"
             },
             "kew": {
               "version": "0.1.7",
-              "from": "kew@0.1.7"
+              "resolved": "https://registry.npmjs.org/kew/-/kew-0.1.7.tgz"
             },
             "ncp": {
               "version": "0.4.2",
-              "from": "ncp@0.4.2",
               "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
             },
             "npmconf": {
               "version": "0.0.24",
-              "from": "npmconf@0.0.24",
               "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-0.0.24.tgz",
               "dependencies": {
                 "config-chain": {
                   "version": "1.1.8",
-                  "from": "config-chain@~1.1.1",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
                   "dependencies": {
                     "proto-list": {
                       "version": "1.2.3",
-                      "from": "proto-list@~1.2.1"
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "1.0.0",
-                  "from": "inherits@~1.0.0"
-                },
-                "once": {
-                  "version": "1.1.1",
-                  "from": "once@~1.1.1"
-                },
-                "osenv": {
-                  "version": "0.0.3",
-                  "from": "osenv@0.0.3",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
-                },
-                "nopt": {
-                  "version": "2.2.1",
-                  "from": "nopt@2",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.5",
-                      "from": "abbrev@1"
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "1.1.4",
-                  "from": "semver@~1.1.0"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                 },
                 "ini": {
                   "version": "1.1.0",
-                  "from": "ini@~1.1.0"
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                },
+                "nopt": {
+                  "version": "2.2.1",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                },
+                "osenv": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+                },
+                "semver": {
+                  "version": "1.1.4",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
                 }
               }
             },
             "progress": {
               "version": "1.1.7",
-              "from": "progress@^1.1.5"
+              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.7.tgz"
             },
             "request": {
               "version": "2.36.0",
-              "from": "request@2.36.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
               "dependencies": {
-                "qs": {
-                  "version": "0.6.6",
-                  "from": "qs@~0.6.0"
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.0",
-                  "from": "json-stringify-safe@~5.0.0"
-                },
-                "mime": {
-                  "version": "1.2.11",
-                  "from": "mime@~1.2.9"
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0"
-                },
-                "node-uuid": {
-                  "version": "1.4.1",
-                  "from": "node-uuid@~1.4.0"
-                },
-                "tough-cookie": {
-                  "version": "0.12.1",
-                  "from": "tough-cookie@>=0.12.0",
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.3.0",
-                      "from": "punycode@>=0.2.0"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.1.4",
-                  "from": "form-data@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
                   "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                    },
                     "combined-stream": {
                       "version": "0.0.5",
-                      "from": "combined-stream@~0.0.4",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                  "dependencies": {
+                    "boom": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
-                    "async": {
-                      "version": "0.9.0",
-                      "from": "async@~0.9.0"
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "hoek": {
+                      "version": "0.9.1",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.2",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.2",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.1",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                },
+                "oauth-sign": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                },
+                "qs": {
+                  "version": "0.6.6",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.0.tgz"
                     }
                   }
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "tunnel-agent@~0.4.0"
-                },
-                "http-signature": {
-                  "version": "0.10.0",
-                  "from": "http-signature@~0.10.0",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.2",
-                      "from": "assert-plus@0.1.2",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                    },
-                    "ctype": {
-                      "version": "0.5.2",
-                      "from": "ctype@0.5.2",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.3.0",
-                  "from": "oauth-sign@~0.3.0"
-                },
-                "hawk": {
-                  "version": "1.0.0",
-                  "from": "hawk@~1.0.0",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "0.9.1",
-                      "from": "hoek@0.9.x"
-                    },
-                    "boom": {
-                      "version": "0.4.2",
-                      "from": "boom@0.4.x"
-                    },
-                    "cryptiles": {
-                      "version": "0.2.2",
-                      "from": "cryptiles@0.2.x"
-                    },
-                    "sntp": {
-                      "version": "0.2.4",
-                      "from": "sntp@0.2.x"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0"
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 }
               }
             },
             "request-progress": {
               "version": "0.3.1",
-              "from": "request-progress@^0.3.1",
+              "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
               "dependencies": {
                 "throttleit": {
                   "version": "0.0.2",
-                  "from": "throttleit@~0.0.2"
+                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
                 }
               }
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@~2.2.2"
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "which": {
               "version": "1.0.5",
-              "from": "which@~1.0.5"
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
             }
           }
         }
@@ -818,27 +767,23 @@
     },
     "karma-script-launcher": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/karma-script-launcher/-/karma-script-launcher-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-script-launcher/-/karma-script-launcher-0.1.0.tgz"
     },
     "mkdirp": {
       "version": "0.3.5",
-      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
     },
     "source-map-support": {
       "version": "0.2.6",
-      "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.6.tgz",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.6.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.1.32",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",
-              "from": "amdefine@0.1.0"
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
         }
@@ -846,225 +791,210 @@
     },
     "watchr": {
       "version": "2.4.11",
-      "from": "https://registry.npmjs.org/watchr/-/watchr-2.4.11.tgz",
       "resolved": "https://registry.npmjs.org/watchr/-/watchr-2.4.11.tgz",
       "dependencies": {
         "bal-util": {
           "version": "2.4.1",
-          "from": "bal-util@2.4.1",
+          "resolved": "https://registry.npmjs.org/bal-util/-/bal-util-2.4.1.tgz",
           "dependencies": {
             "ambi": {
               "version": "2.1.6",
-              "from": "ambi@2.1.6"
+              "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.1.6.tgz"
             }
           }
         },
-        "typechecker": {
-          "version": "2.0.8",
-          "from": "typechecker@2.0.8"
+        "eachr": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/eachr/-/eachr-2.0.2.tgz"
         },
         "extendr": {
           "version": "2.1.0",
-          "from": "extendr@2.1.0"
+          "resolved": "https://registry.npmjs.org/extendr/-/extendr-2.1.0.tgz"
         },
-        "eachr": {
-          "version": "2.0.2",
-          "from": "eachr@2.0.2"
+        "extract-opts": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-2.2.0.tgz"
+        },
+        "ignorefs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ignorefs/-/ignorefs-1.0.0.tgz",
+          "dependencies": {
+            "ignorepatterns": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/ignorepatterns/-/ignorepatterns-1.0.1.tgz"
+            }
+          }
         },
         "safefs": {
           "version": "3.1.1",
-          "from": "safefs@3.1.1",
+          "resolved": "https://registry.npmjs.org/safefs/-/safefs-3.1.1.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@2.0.3"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             }
           }
         },
         "taskgroup": {
           "version": "3.3.9",
-          "from": "https://registry.npmjs.org/taskgroup/-/taskgroup-3.3.9.tgz",
           "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-3.3.9.tgz",
           "dependencies": {
             "ambi": {
               "version": "2.1.6",
-              "from": "ambi@2.1.6"
+              "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.1.6.tgz"
             },
             "extendonclass": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/extendonclass/-/extendonclass-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/extendonclass/-/extendonclass-1.0.1.tgz"
             }
           }
         },
-        "ignorefs": {
-          "version": "1.0.0",
-          "from": "ignorefs@1.0.0",
-          "dependencies": {
-            "ignorepatterns": {
-              "version": "1.0.1",
-              "from": "ignorepatterns@1.0.1"
-            }
-          }
-        },
-        "extract-opts": {
-          "version": "2.2.0",
-          "from": "extract-opts@2.2.0"
+        "typechecker": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz"
         }
       }
     },
     "webpack": {
       "version": "1.0.0-rc11",
-      "from": "https://registry.npmjs.org/webpack/-/webpack-1.0.0-rc11.tgz",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.0.0-rc11.tgz",
       "dependencies": {
-        "esprima": {
-          "version": "1.0.4",
-          "from": "esprima@1.0.4"
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "from": "optimist@0.6.1",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "from": "wordwrap@0.0.2"
-            },
-            "minimist": {
-              "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            }
-          }
-        },
-        "uglify-js": {
-          "version": "2.4.13",
-          "from": "uglify-js@2.4.13",
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.33",
-              "from": "source-map@0.1.33",
-              "dependencies": {
-                "amdefine": {
-                  "version": "0.1.0",
-                  "from": "amdefine@0.1.0"
-                }
-              }
-            },
-            "optimist": {
-              "version": "0.3.7",
-              "from": "optimist@0.3.7",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "from": "wordwrap@0.0.2"
-                }
-              }
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "from": "uglify-to-browserify@1.0.2"
-            }
-          }
-        },
         "async": {
           "version": "0.2.10",
-          "from": "async@0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
-        "enhanced-resolve": {
-          "version": "0.7.4",
-          "from": "enhanced-resolve@0.7.4",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "2.0.3",
-              "from": "graceful-fs@2.0.3"
-            }
-          }
+        "base64-encode": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/base64-encode/-/base64-encode-1.0.1.tgz"
         },
         "clone": {
           "version": "0.1.15",
-          "from": "https://registry.npmjs.org/clone/-/clone-0.1.15.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.15.tgz"
         },
-        "webpack-core": {
-          "version": "0.3.4",
-          "from": "webpack-core@0.3.4",
+        "enhanced-resolve": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.7.4.tgz",
           "dependencies": {
-            "source-map": {
-              "version": "0.1.33",
-              "from": "source-map@0.1.33",
-              "dependencies": {
-                "amdefine": {
-                  "version": "0.1.0",
-                  "from": "amdefine@0.1.0"
-                }
-              }
+            "graceful-fs": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             }
           }
         },
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+        },
         "node-libs-browser": {
           "version": "0.1.2",
-          "from": "node-libs-browser@0.1.2",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.1.2.tgz",
           "dependencies": {
-            "console-browserify": {
-              "version": "0.1.6",
-              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz"
-            },
-            "vm-browserify": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.1.tgz"
-            },
-            "crypto-browserify": {
-              "version": "0.2.1",
-              "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.1.tgz"
-            },
-            "http-browserify": {
-              "version": "0.1.6",
-              "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-0.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-0.1.6.tgz",
-              "dependencies": {
-                "concat-stream": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-0.0.8.tgz"
-                }
-              }
-            },
             "buffer-browserify": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/buffer-browserify/-/buffer-browserify-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/buffer-browserify/-/buffer-browserify-0.0.4.tgz",
               "dependencies": {
                 "base64-js": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz"
                 }
               }
             },
+            "console-browserify": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz"
+            },
+            "crypto-browserify": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.1.tgz"
+            },
+            "http-browserify": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-0.1.6.tgz",
+              "dependencies": {
+                "concat-stream": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-0.0.8.tgz"
+                }
+              }
+            },
+            "vm-browserify": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.1.tgz"
+            },
             "zlib-browserify": {
               "version": "0.0.1",
-              "from": "zlib-browserify@0.0.1"
+              "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.1.tgz"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
         "tapable": {
           "version": "0.1.5",
-          "from": "tapable@0.1.5"
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.5.tgz"
         },
-        "base64-encode": {
-          "version": "1.0.1",
-          "from": "base64-encode@1.0.1"
+        "uglify-js": {
+          "version": "2.4.13",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.13.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.1.33",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            }
+          }
+        },
+        "webpack-core": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.3.4.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.33",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
         }
       }
     },
     "when": {
       "version": "3.1.0",
-      "from": "when@3.1.0",
       "resolved": "https://registry.npmjs.org/when/-/when-3.1.0.tgz"
     }
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,46 +4,184 @@
   "npm-shrinkwrap-version": "5.1.0",
   "dependencies": {
     "eslint": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.4.2.tgz",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.13.0.tgz",
       "dependencies": {
         "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
-            "has-color": {
-              "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+            "has-ansi": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
             },
             "strip-ansi": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.4.7",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "doctrine": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.3.0.tgz"
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.2.tgz",
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "escope": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-1.0.0.tgz"
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-2.0.3.tgz",
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.5",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.5.tgz"
+                },
+                "es6-iterator": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
+                },
+                "es6-set": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
+                },
+                "es6-symbol": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                },
+                "event-emitter": {
+                  "version": "0.3.3",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.5",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.5.tgz"
+                },
+                "es6-iterator": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
+                },
+                "es6-symbol": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-1.2.0.tgz"
+            },
+            "util-extend": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz"
+            }
+          }
         },
-        "esprima": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.3.tgz"
+        "espree": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-1.7.1.tgz"
         },
         "estraverse": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
+        },
+        "estraverse-fb": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.0.tgz"
+        },
+        "globals": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-5.1.0.tgz"
         },
         "js-yaml": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
@@ -65,41 +203,63 @@
             }
           }
         },
+        "minimatch": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+        },
         "optionator": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.1.1.tgz",
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
           "dependencies": {
             "deep-is": {
               "version": "0.1.3",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             },
-            "levenshtein-damerau": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/levenshtein-damerau/-/levenshtein-damerau-0.1.0.tgz"
+            "fast-levenshtein": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
             },
             "levn": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
             },
             "prelude-ls": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.0.3.tgz"
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
             },
             "type-check": {
               "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
             },
             "wordwrap": {
               "version": "0.0.2",
@@ -108,12 +268,20 @@
           }
         },
         "strip-json-comments": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
         },
         "text-table": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+        },
+        "xml-escape": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,8 +1,12 @@
 {
   "name": "jester-tester",
-  "version": "2.0.0",
+  "version": "3.0.0-alpha2",
   "npm-shrinkwrap-version": "5.1.0",
   "dependencies": {
+    "deepmerge": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-0.2.7.tgz"
+    },
     "eslint": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.13.0.tgz",
@@ -287,7 +291,7 @@
     },
     "eslint-path-formatter": {
       "version": "0.2.0",
-      "from": "eslint-path-formatter@git://github.com/jauco/eslint-path-formatter",
+      "from": "eslint-path-formatter@git://github.com/jauco/eslint-path-formatter#216df915eec8a8510cae878e3da2605ca372a290",
       "resolved": "git://github.com/jauco/eslint-path-formatter#216df915eec8a8510cae878e3da2605ca372a290",
       "dependencies": {
         "source-map": {
@@ -1025,74 +1029,238 @@
       }
     },
     "webpack": {
-      "version": "1.0.0-rc11",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.0.0-rc11.tgz",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.5.3.tgz",
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        },
-        "base64-encode": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/base64-encode/-/base64-encode-1.0.1.tgz"
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "clone": {
-          "version": "0.1.15",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.15.tgz"
+          "version": "0.1.19",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
         },
         "enhanced-resolve": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.7.4.tgz",
+          "version": "0.8.4",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.8.4.tgz",
           "dependencies": {
             "graceful-fs": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+              "version": "3.0.5",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
             }
           }
         },
         "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz"
+        },
+        "memory-fs": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
         },
         "node-libs-browser": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.1.2.tgz",
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.4.1.tgz",
           "dependencies": {
-            "buffer-browserify": {
-              "version": "0.0.4",
-              "resolved": "https://registry.npmjs.org/buffer-browserify/-/buffer-browserify-0.0.4.tgz",
+            "assert": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+            },
+            "browserify-zlib": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.5",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
+                }
+              }
+            },
+            "buffer": {
+              "version": "2.8.2",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
               "dependencies": {
                 "base64-js": {
-                  "version": "0.0.2",
-                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz"
+                  "version": "0.0.7",
+                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
+                },
+                "ieee754": {
+                  "version": "1.1.4",
+                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+                },
+                "is-array": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
                 }
               }
             },
             "console-browserify": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz"
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                }
+              }
+            },
+            "constants-browserify": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
             },
             "crypto-browserify": {
-              "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.1.tgz"
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
+              "dependencies": {
+                "browserify-aes": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "pbkdf2-compat": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+                },
+                "ripemd160": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+                },
+                "sha.js": {
+                  "version": "2.2.6",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+                }
+              }
+            },
+            "domain-browser": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+            },
+            "events": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
             },
             "http-browserify": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-0.1.6.tgz",
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
               "dependencies": {
-                "concat-stream": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-0.0.8.tgz"
+                "Base64": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "https-browserify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+            },
+            "os-browserify": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+            },
+            "path-browserify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+            },
+            "process": {
+              "version": "0.8.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.8.0.tgz"
+            },
+            "punycode": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            },
+            "querystring-es3": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "stream-browserify": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "timers-browserify": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.3.0.tgz",
+              "dependencies": {
+                "process": {
+                  "version": "0.10.0",
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.10.0.tgz"
+                }
+              }
+            },
+            "tty-browserify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+            },
+            "url": {
+              "version": "0.10.2",
+              "resolved": "https://registry.npmjs.org/url/-/url-0.10.2.tgz"
+            },
+            "util": {
+              "version": "0.10.3",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "vm-browserify": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.1.tgz"
-            },
-            "zlib-browserify": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.1.tgz"
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "dependencies": {
+                "indexof": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                }
+              }
             }
           }
         },
@@ -1111,13 +1279,17 @@
           }
         },
         "tapable": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.5.tgz"
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.8.tgz"
         },
         "uglify-js": {
-          "version": "2.4.13",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.13.tgz",
+          "version": "2.4.16",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
           "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
             "optimist": {
               "version": "0.3.7",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
@@ -1129,8 +1301,8 @@
               }
             },
             "source-map": {
-              "version": "0.1.33",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
+              "version": "0.1.34",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
@@ -1144,13 +1316,119 @@
             }
           }
         },
+        "watchpack": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.3.tgz",
+          "dependencies": {
+            "chokidar": {
+              "version": "1.0.0-rc3",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.0-rc3.tgz",
+              "dependencies": {
+                "anymatch": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.1.0.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "async-each": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                },
+                "glob-parent": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.0.0.tgz",
+                  "dependencies": {
+                    "is-glob": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-0.3.0.tgz"
+                    }
+                  }
+                },
+                "is-binary-path": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+                  "dependencies": {
+                    "binary-extensions": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.0.2.tgz"
+                    }
+                  }
+                },
+                "readdirp": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.5",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+            }
+          }
+        },
         "webpack-core": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.3.4.tgz",
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.4.8.tgz",
           "dependencies": {
             "source-map": {
-              "version": "0.1.33",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
+              "version": "0.1.43",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -567,8 +567,8 @@
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
                 },
                 "i": {
-                  "version": "0.3.2",
-                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
+                  "version": "0.3.3",
+                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                 },
                 "ncp": {
                   "version": "0.4.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -286,12 +286,13 @@
       }
     },
     "eslint-path-formatter": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-path-formatter/-/eslint-path-formatter-0.1.1.tgz",
+      "version": "0.2.0",
+      "from": "eslint-path-formatter@git://github.com/jauco/eslint-path-formatter",
+      "resolved": "git://github.com/jauco/eslint-path-formatter#216df915eec8a8510cae878e3da2605ca372a290",
       "dependencies": {
         "source-map": {
-          "version": "0.1.33",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "licence": "MIT",
   "dependencies": {
+    "deepmerge": "~0.2.7",
     "eslint": "0.13.0",
     "eslint-path-formatter": "git@github.com:jauco/eslint-path-formatter.git#v0.2.0",
     "glob": "3.2.8",
@@ -28,9 +29,8 @@
     "mkdirp": "0.3.5",
     "source-map-support": "~0.2.5",
     "watchr": "2.4.11",
-    "webpack": "1.0.0-rc11",
-    "when": "~3.1.0",
-    "deepmerge": "~0.2.7"
+    "webpack": "1.5.3",
+    "when": "~3.1.0"
   },
   "devDependencies": {
     "npm-shrinkwrap": "~5.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "3.0.0-alpha8",
+  "version": "3.0.0-alpha9",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",

--- a/package.json
+++ b/package.json
@@ -12,23 +12,26 @@
   },
   "licence": "MIT",
   "dependencies": {
-    "karma-script-launcher": "0.1.0",
+    "eslint": "0.4.2",
+    "eslint-path-formatter": "0.1.1",
+    "glob": "3.2.8",
+    "jsdoc": "3.3.0-alpha8",
+    "json-loader": "~0.5.0",
+    "karma": "0.12.13",
     "karma-chrome-launcher": "0.1.2",
     "karma-firefox-launcher": "0.1.3",
-    "karma-jasmine": "0.2.2",
-    "karma-phantomjs-launcher": "0.1.2",
-    "karma-junit-reporter": "0.2.1",
     "karma-ie-launcher": "0.1.3",
-    "karma": "0.12.13",
-    "webpack": "1.0.0-rc11",
-    "eslint": "0.4.2",
-    "watchr": "2.4.11",
+    "karma-jasmine": "0.2.2",
+    "karma-junit-reporter": "0.2.1",
+    "karma-phantomjs-launcher": "0.1.2",
+    "karma-script-launcher": "0.1.0",
     "mkdirp": "0.3.5",
-    "glob": "3.2.8",
-    "eslint-path-formatter": "0.1.1",
     "source-map-support": "~0.2.5",
-    "json-loader": "~0.5.0",
-    "jsdoc": "3.3.0-alpha8",
+    "watchr": "2.4.11",
+    "webpack": "1.0.0-rc11",
     "when": "~3.1.0"
+  },
+  "devDependencies": {
+    "npm-shrinkwrap": "~5.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "2.0.0",
+  "version": "3.0.0-alpha",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",
@@ -13,7 +13,7 @@
   "licence": "MIT",
   "dependencies": {
     "eslint": "0.13.0",
-    "eslint-path-formatter": "0.1.1",
+    "eslint-path-formatter": "git@github.com:jauco/eslint-path-formatter.git#v0.2.0",
     "glob": "3.2.8",
     "jsdoc": "3.3.0-alpha8",
     "json-loader": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "3.0.0-alpha12",
+  "version": "3.0.0-alpha13",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "3.0.0-alpha6",
+  "version": "3.0.0-alpha7",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
     "source-map-support": "~0.2.5",
     "watchr": "2.4.11",
     "webpack": "1.0.0-rc11",
-    "when": "~3.1.0"
+    "when": "~3.1.0",
+    "deepmerge": "~0.2.7"
   },
   "devDependencies": {
     "npm-shrinkwrap": "~5.1.0"
-  }
+  },
+  "main": "src/lib/api.js"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "3.0.0-alpha7",
+  "version": "3.0.0-alpha8",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",
@@ -13,7 +13,7 @@
   "licence": "MIT",
   "dependencies": {
     "deepmerge": "~0.2.7",
-    "eslint": "0.13.0",
+    "eslint": "0.17.1",
     "eslint-path-formatter": "git@github.com:jauco/eslint-path-formatter.git#v0.2.0",
     "glob": "3.2.8",
     "jsdoc": "3.3.0-alpha8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "3.0.0-alpha3",
+  "version": "3.0.0-alpha4",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "3.0.0-alpha",
+  "version": "3.0.0-alpha2",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "3.0.0-alpha4",
+  "version": "3.0.0-alpha6",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "3.0.0-alpha9",
+  "version": "3.0.0-alpha11",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "3.0.0-alpha2",
+  "version": "3.0.0-alpha3",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "licence": "MIT",
   "dependencies": {
-    "eslint": "0.4.2",
+    "eslint": "0.13.0",
     "eslint-path-formatter": "0.1.1",
     "glob": "3.2.8",
     "jsdoc": "3.3.0-alpha8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "3.0.0-alpha11",
+  "version": "3.0.0-alpha12",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "karma-phantomjs-launcher": "0.1.2",
     "karma-script-launcher": "0.1.0",
     "mkdirp": "0.3.5",
-    "source-map-support": "~0.2.5",
     "watchr": "2.4.11",
     "webpack": "1.5.3",
     "when": "~3.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jester-tester",
   "description": "Get your project tested and out there with minimal fuss.",
   "repository": "https://github.com/jauco/jester",
-  "version": "3.0.0-alpha13",
+  "version": "3.0.0-alpha14",
   "author": "Jauco Noordzij <code@jauco.nl>",
   "bin": {
     "jester-watch": "./src/bin/jester-watch.js",

--- a/src/bin/jester-batch.js
+++ b/src/bin/jester-batch.js
@@ -11,7 +11,7 @@ var loadConfig = require("../lib/loadConfig"),
 
 var config = loadConfig();
 
-rebuildProject(config.webpackOptions, config.fullEntryGlob, config.artifactPath, config.webpackWarningFilters)
+rebuildProject(config.webpackOptions, config.fullEntryGlob, config.webpackWarningFilters)
     .then(function() {
         if(config.srcPath && config.apiDocPath) {
             return rebuildDocumentation(config.srcPath, config.apiDocPath, config.jsdocConf, config.readme);

--- a/src/bin/jester-batch.js
+++ b/src/bin/jester-batch.js
@@ -7,7 +7,7 @@ var loadConfig = require("../lib/loadConfig"),
     runAllTests = require("../lib/runAllTests"),
     when = require("when");
 
-var config = loadConfig("./jester.json");
+var config = loadConfig();
 
 rebuildProject(config.webpackOptions, config.fullEntryGlob, config.artifactPath, config.webpackWarningFilters)
     .then(function() {

--- a/src/bin/jester-batch.js
+++ b/src/bin/jester-batch.js
@@ -11,7 +11,7 @@ var loadConfig = require("../lib/loadConfig"),
 
 var config = loadConfig();
 
-rebuildProject(config.webpackOptions, config.fullEntryGlob, config.webpackWarningFilters)
+rebuildProject(config.webpackOptions, config.webpackWarningFilters)
     .then(function() {
         if(config.srcPath && config.apiDocPath) {
             return rebuildDocumentation(config.srcPath, config.apiDocPath, config.jsdocConf, config.readme);

--- a/src/bin/jester-batch.js
+++ b/src/bin/jester-batch.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
+/*eslint no-process-exit: 0*/
 "use strict";
 
 var loadConfig = require("../lib/loadConfig"),
     rebuildDocumentation = require("../lib/rebuildDocumentation"),
     rebuildProject = require("../lib/rebuildProject"),
-    runAllTests = require("../lib/runAllTests"),
-    when = require("when");
+    runAllTests = require("../lib/runAllTests");
 
 var config = loadConfig();
 
@@ -14,7 +14,7 @@ rebuildProject(config.webpackOptions, config.fullEntryGlob, config.artifactPath,
         if(config.srcPath && config.apiDocPath) {
             return rebuildDocumentation(config.srcPath, config.apiDocPath, config.jsdocConf, config.readme);
         } else {
-            console.log("please configure srcPath and apiDocPath in order to generate jsdoc documentation")
+            console.log("please configure srcPath and apiDocPath in order to generate jsdoc documentation");
         }
     })
     .then(function() {

--- a/src/bin/jester-batch.js
+++ b/src/bin/jester-batch.js
@@ -2,6 +2,8 @@
 /*eslint no-process-exit: 0*/
 "use strict";
 
+require("../lib/addProjectDirToSearchPath");
+
 var loadConfig = require("../lib/loadConfig"),
     rebuildDocumentation = require("../lib/rebuildDocumentation"),
     rebuildProject = require("../lib/rebuildProject"),

--- a/src/bin/jester-batch.js
+++ b/src/bin/jester-batch.js
@@ -9,7 +9,7 @@ var loadConfig = require("../lib/loadConfig"),
 
 var config = loadConfig("./jester.json");
 
-rebuildProject(config.fullEntryGlob, config.artifactPath, config.webpackWarningFilters)
+rebuildProject(config.webpackOptions, config.fullEntryGlob, config.artifactPath, config.webpackWarningFilters)
     .then(function() {
         if(config.srcPath && config.apiDocPath) {
             return rebuildDocumentation(config.srcPath, config.apiDocPath, config.jsdocConf, config.readme);

--- a/src/bin/jester-doc.js
+++ b/src/bin/jester-doc.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/*eslint no-process-exit: 0*/
 "use strict";
 
 var loadConfig = require("../lib/loadConfig"),

--- a/src/bin/jester-doc.js
+++ b/src/bin/jester-doc.js
@@ -4,10 +4,9 @@
 var loadConfig = require("../lib/loadConfig"),
     rebuildDocumentation = require("../lib/rebuildDocumentation");
 
-var config = loadConfig("./jester.json");
+var config = loadConfig();
 
 rebuildDocumentation(config.srcPath, config.apiDocPath, config.jsdocConf, config.readme)
     .done(function(exitCode) {
         process.exit(exitCode);
     });
-

--- a/src/bin/jester-init.js
+++ b/src/bin/jester-init.js
@@ -48,7 +48,7 @@ var jester = require("jester-tester");\n\
 module.exports = jester.deepMergeForWebpack({\n\
   //entry is provided by jester\n\
   output: {\n\
-    path: ' + json.stringify(ARTIFACT_PATH) + ', \n\
+    path: ' + JSON.stringify(ARTIFACT_PATH) + ', \n\
     filename: "[name].min.js",\n\
     chunkFilename: "[id].chunk.js",\n\
     namedChunkFilename: "[name].chunk.js"\n\

--- a/src/bin/jester-init.js
+++ b/src/bin/jester-init.js
@@ -5,6 +5,7 @@ var fs = require("fs"),
     p = require("path");
 
 var FEATURES_PATH = "features/";
+var ARTIFACT_PATH = "./build/artifacts";
 
 var defaultConf = {
     eslintRulesDir: "./eslint-rules/",
@@ -14,7 +15,6 @@ var defaultConf = {
     readme: "./readme.md",
     entryGlob: FEATURES_PATH + "*/feature.js",
     karmaPath: "./build/karma/",
-    artifactPath: "./build/artifacts",
     karmaOptions: {
         proxies: {},
         browsers: ['Chrome', 'Firefox', 'IE', 'PhantomJS'],
@@ -48,7 +48,7 @@ var jester = require("jester-tester");\n\
 module.exports = jester.deepMergeForWebpack({\n\
   //entry is provided by jester\n\
   output: {\n\
-    //outputpath is provided by jester\n\
+    path: ' + json.stringify(ARTIFACT_PATH) + ', \n\
     filename: "[name].min.js",\n\
     chunkFilename: "[id].chunk.js",\n\
     namedChunkFilename: "[name].chunk.js"\n\
@@ -73,7 +73,7 @@ mkdirp(p.resolve(defaultConf.karmaPath));
 mkdirp(p.join(defaultConf.srcPath, FEATURES_PATH));
 mkdirp(p.join(defaultConf.srcPath, 'lib'));
 mkdirp(p.join(defaultConf.srcPath, 'app', 'domain'));
-mkdirp(p.resolve(defaultConf.artifactPath));
+mkdirp(p.resolve(ARTIFACT_PATH));
 
 mkdirp(p.resolve(defaultConf.apiDocPath));
 

--- a/src/bin/jester-init.js
+++ b/src/bin/jester-init.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
+"use strict";
 
-var fs = require('fs'),
+var fs = require("fs"),
     p = require("path");
 
 var FEATURES_PATH = "features/"
@@ -36,7 +37,22 @@ var defaultJSDocConf = {
             "outputSourceFiles": true
         }
     }
-}
+};
+
+var defaultWebpackConfig = '"use strict";\n\
+module.exports = {\n\
+    output: {\n\
+        filename: "[name].min.js",\n\
+        chunkFilename: "[id].chunk.js",\n\
+        namedChunkFilename: "[name].chunk.js"\n\
+    },\n\
+    module: {\n\
+        loaders: [\n\
+            {test: /\.json$/, loader: "json-loader"},\n\
+        ]\n\
+    },\n\
+    devtool: "#source-map",\n\
+};\n';
 
 var defaultReadme = "# README \n\
   \n\
@@ -66,3 +82,4 @@ function writeFileIfNotExists(path, contents) {
 writeFileIfNotExists("./jester.json", JSON.stringify(defaultConf, null, 4));
 writeFileIfNotExists(defaultConf.jsdocConf, JSON.stringify(defaultJSDocConf, null, 4));
 writeFileIfNotExists(defaultConf.readme, defaultReadme);
+writeFileIfNotExists("./webpack.config.js", defaultWebpackConfig);

--- a/src/bin/jester-init.js
+++ b/src/bin/jester-init.js
@@ -17,128 +17,6 @@ var defaultConf = {
     karmaOptions: {
         proxies: {},
         browsers: ['Chrome', 'Firefox', 'IE', 'PhantomJS'],
-    },
-
-    eslintRules: {
-        "no-cond-assign": 2, //disallow assignment in conditional expressions
-        "no-console": 1, //disallow use of console
-        "no-comma-dangle": 2, //disallow trailing commas in object literals
-        "no-control-regex": 2, //disallow control characters in regular expressions
-        "no-debugger": 1, //disallow use of debugger
-        "no-dupe-keys": 2, //disallow duplicate keys when creating object literals
-        "no-empty": 2, //disallow empty statements
-        "no-empty-class": 2, //disallow the use of empty character classes in regular expressions
-        "no-ex-assign": 2, //disallow assigning to the exception in a catch block
-        "no-extra-boolean-cast": 2, //disallow double-negation boolean casts in a boolean context
-        "no-extra-parens": 1, //disallow unnecessary parentheses
-        "no-extra-semi": 2, //disallow unnecessary semicolons
-        "no-func-assign": 2, //disallow overwriting functions written as function declarations
-        "no-invalid-regexp": 2, //disallow invalid regular expression strings in the RegExp constructor
-        "no-negated-in-lhs": 2, //disallow negation of the left operand of an in expression
-        "no-obj-calls": 2, //disallow the use of object properties of the global object (Math and JSON) as functions
-        "no-regex-spaces": 2, //disallow multiple spaces in a regular expression literal
-        "no-spare-arrays": 0, //disallow sparse arrays
-        "no-unreachable": 2, //disallow unreachable statements after a return, throw, continue, or break statement
-        "use-isnan": 2, //disallow comparisons with the value NaN
-        "valid-jsdoc": 1, //Ensure JSDoc comments are valid (off by default)
-
-        //These are rules designed to prevent you from making mistakes. They either prescribe a better way of doing something or help you avoid footguns.
-        "block-scoped-var": 0, //treat var statements as if they were block scoped
-        "complexity": [2, 20], //specify the maximum cyclomatic complexity allowed in a program
-        "consistent-return": 2, //require return statements to either always or never specify values
-        "curly": [2, "all"], //specify curly brace conventions for all control statements
-        "dot-notation": 0, //encourages use of dot notation whenever possible
-        "eqeqeq": 2, //require the use of === and !==
-        "guard-for-in": 2, //make sure for-in loops have an if statement (off by default)
-        "no-alert": 1, //disallow the use of alert, confirm, and prompt
-        "no-caller": 2, //disallow use of arguments.caller or arguments.callee
-        "no-div-regex": 2, //disallow division operators explicitly at beginning of regular expression
-        "no-else-return": 0, //disallow else after a return in an if.
-        "no-empty-label": 2, //disallow use of labels for anything other then loops and switches
-        "no-eq-null": 2, //disallow comparisons to null without a type-checking operator
-        "no-eval": 2, //disallow use of eval()
-        "no-extend-native": 2, //disallow adding to native types
-        "no-fallthrough": 2, //disallow fallthrough of case statements
-        "no-floating-decimal": 2, //disallow the use of leading or trailing decimal points in numeric literals
-        "no-implied-eval": 2, //disallow use of eval()-like methods
-        "no-labels": 2, //disallow use of labeled statements
-        "no-iterator": 2, //disallow usage of __iterator__ property
-        "no-lone-blocks": 2, //disallow unnecessary nested blocks
-        "no-loop-func": 2, //disallow creation of functions within loops
-        "no-multi-str": 0, //disallow use of multiline strings (the browser test will catch this if necessary)
-        "no-native-reassign": 2, //disallow reassignments of native objects
-        "no-new": 2, //disallow use of new operator when not part of the assignment or comparison
-        "no-new-func": 2, //disallow use of new operator for Function object
-        "no-new-wrappers": 2, //disallows creating new instances of String,Number, and Boolean
-        "no-octal": 2, //disallow use of octal literals
-        "no-octal-escape": 2, //disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251"; use unicode
-        "no-proto": 2, //disallow usage of __proto__ property
-        "no-redeclare": 2, //disallow declaring the same variable more then once
-        "no-return-assign": 2, //disallow use of assignment in return statement
-        "no-script-url": 2, //disallow use of javascript: urls.
-        "no-self-compare": 2, //disallow comparisons where both sides are exactly the same
-        "no-unused-expressions": 2, //disallow usage of expressions in statement position
-        "no-with": 2, //disallow use of the with statement
-        "no-yoda": 2, //disallow Yoda conditions
-        "radix": 2, //require use of the second argument for parseInt()
-        "wrap-iife": 2, //require immediate function invocation to be wrapped in parentheses
-
-        //These rules relate to using strict mode.
-        //strict mode is enforced externally.
-        "no-global-strict": 0, //disallow the "use strict" pragma in the global scope
-        "no-extract-strict": 0, //disallow unnecessary use of "use strict"; when already in strict mode
-        "strict": 0, //require that all functions are run in strict mode
-
-        //These rules have to do with variable declarations.
-        "no-catch-shadow": 2, //disallow the catch clause parameter name being the same as a variable in the outer scope
-        "no-delete-var": 2, //disallow deletion of variables
-        "no-label-var": 2, //disallow labels that share a name with a variable
-        "no-shadow": 2, //disallow declaration of variables already declared in the outer scope
-        "no-shadow-restricted-names": 2, //disallow shadowing of names such as arguments
-        "no-undef": 2, //disallow use of undeclared variables unless mentioned in a /*global */ block
-        "no-undef-init": 2, //disallow use of undefined when initializing variables (stylistic yes, but good to be consequent)
-        "no-unused-vars": 0, //disallow declaration of variables that are not used in the code
-        "no-use-before-define": 2, //disallow use of variables before they are defined
-
-        //These rules are specific to JavaScript running on Node.js.
-        "no-mixed-requires": 0, //disallow mixing regular variable and require declarations
-        "no-path-concat": 2, //disallow string concatenation with __dirname and __filename
-        "no-process-exit": 2, //disallow process.exit()
-        "no-sync": 1, //disallow use of synchronous methods (off by default)
-
-        //These rules are purely matters of style and are quite subjective.
-        "brace-style": 2, //enforce one true brace style
-        "camelcase": 2, //require camel case names
-        "consistent-this": [2, "self"], //enforces consistent naming when capturing the current execution context (off by default)
-        "func-names": 0, //require function expressions to have a name
-        "func-style": [2, "declaration"], //enforces use of function declarations or expressions
-        "new-cap": 2, //require a capital letter for constructors
-        "new-parens": 2, //disallow the omission of parentheses when invoking a contructor with no arguments
-        "no-nested-ternary": 2, //disallow nested ternary expressions
-        "no-array-constructor": 2, //disallow use of the Array constructor
-        "no-new-object": 2, //disallow use of the Object constructor
-        "no-spaced-func": 2, //disallow space between function identifier and application
-        "no-ternary": 0, //disallow the use of ternary operators
-        "no-underscore-dangle": 0, //disallow dangling underscores in identifiers
-        "no-wrap-func": 2, //disallow wrapping of none IIFE statements in parents
-        "quotes": [1, "double", "avoid-escape"], //specify whether double or single quotes should be used
-        "quote-props": 0, //require quotes around object literal property names
-        "semi": 2, //require use of semicolons instead of relying on ASI
-        "sort-vars": 0, //sort variables within the same declaration block
-        "space-infix-ops": 2, //require spaces around operators
-        "space-return-throw-case": 2, //require a space after return, throw, and case
-        "space-unary-word-ops": 2, //require a space around word operators such as typeof
-        "max-nested-callbacks": [1, 5], //specify the maximum depth callbacks can be nested
-        "one-var": 0, //allow just one var statement per function
-        "wrap-regex": 0, //require regex literals to be wrapped in parentheses
-
-        //The following rules are included for compatibility with JSHint and JSLint. While the names of the rules may not match up with the JSHint/JSLint counterpart, the functionality is the same.
-        "max-depth": 0, //specify the maximum depth that blocks can be nested (off by default)
-        "max-len": 0, //specify the maximum length of a line in your program (off by default)
-        "max-params": 0, //limits the number of parameters that can be used in the function declaration. (off by default)
-        "max-statements": 0, //specify the maximum number of statement allowed in a function (off by default)
-        "no-bitwise": 1, //disallow use of bitwise operators (off by default)
-        "no-plusplus": 0 //disallow use of unary operators, ++ and -- (off by default)
     }
 };
 
@@ -175,7 +53,6 @@ mkdirp(p.join(defaultConf.srcPath, 'app', 'domain'));
 mkdirp(p.resolve(defaultConf.artifactPath));
 
 mkdirp(p.resolve(defaultConf.apiDocPath));
-mkdirp(p.resolve(defaultConf.eslintRulesDir));
 
 function writeFileIfNotExists(path, contents) {
     if(fs.existsSync(path)) {

--- a/src/bin/jester-init.js
+++ b/src/bin/jester-init.js
@@ -72,7 +72,6 @@ var mkdirp = require('mkdirp');
 mkdirp(p.resolve(defaultConf.karmaPath));
 mkdirp(p.join(defaultConf.srcPath, FEATURES_PATH));
 mkdirp(p.join(defaultConf.srcPath, 'lib'));
-mkdirp(p.join(defaultConf.srcPath, 'app', 'domain'));
 mkdirp(p.resolve(ARTIFACT_PATH));
 
 mkdirp(p.resolve(defaultConf.apiDocPath));

--- a/src/bin/jester-init.js
+++ b/src/bin/jester-init.js
@@ -46,7 +46,9 @@ var defaultWebpackConfig = '"use strict";\n\
 //own settings overwrite the MINIMAL settings. This will probably break things.\n\
 var jester = require("jester-tester");\n\
 module.exports = jester.deepMergeForWebpack({\n\
-  //entry is provided by jester\n\
+  entry: {\n\
+    "app": "./src/app.js"\n\
+  },\n\
   output: {\n\
     path: ' + JSON.stringify(ARTIFACT_PATH) + ', \n\
     filename: "[name].min.js",\n\

--- a/src/bin/jester-init.js
+++ b/src/bin/jester-init.js
@@ -61,6 +61,20 @@ module.exports = jester.deepMergeForWebpack({\n\
 }, jester.MINIMAL_REQUIRED_CONFIG);\n\
 //console.log(module.exports); //to see the config that is used.\n';
 
+var defaulteslintrc = {
+  "env": {
+    "browser": true
+  },
+  "globals": {
+    "require": false,
+    "module": false
+  },
+  "rules": {
+    "strict": [2, "global"],
+    "global-strict": 0
+  }
+};
+
 var defaultReadme = "# README \n\
   \n\
   * Replace this readme with useful info about your app \n\
@@ -86,6 +100,7 @@ function writeFileIfNotExists(path, contents) {
 }
 
 writeFileIfNotExists("./jester.json", JSON.stringify(defaultConf, null, 4));
+writeFileIfNotExists("./.eslintrc", JSON.stringify(defaulteslintrc, null, 4));
 writeFileIfNotExists(defaultConf.jsdocConf, JSON.stringify(defaultJSDocConf, null, 4));
 writeFileIfNotExists(defaultConf.readme, defaultReadme);
 writeFileIfNotExists("./webpack.config.js", defaultWebpackConfig);

--- a/src/bin/jester-init.js
+++ b/src/bin/jester-init.js
@@ -40,19 +40,26 @@ var defaultJSDocConf = {
 };
 
 var defaultWebpackConfig = '"use strict";\n\
-module.exports = {\n\
-    output: {\n\
-        filename: "[name].min.js",\n\
-        chunkFilename: "[id].chunk.js",\n\
-        namedChunkFilename: "[name].chunk.js"\n\
-    },\n\
-    module: {\n\
-        loaders: [\n\
-            {test: /\.json$/, loader: "json-loader"},\n\
-        ]\n\
-    },\n\
-    devtool: "#source-map",\n\
-};\n';
+//MINIMAL_REQUIRED_CONFIG contains those few options that are needed for webpack\n\
+//to integrate with the rest of the tools. You can override them by making\n\
+//MINIMAL_REQUIRED_CONFIG the first argument to the deepmerge function so your\n\
+//own settings overwrite the MINIMAL settings. This will probably break things.\n\
+var jester = require("jester-tester");\n\
+module.exports = jester.deepMergeForWebpack({\n\
+  //entry is provided by jester\n\
+  output: {\n\
+    //outputpath is provided by jester\n\
+    filename: "[name].min.js",\n\
+    chunkFilename: "[id].chunk.js",\n\
+    namedChunkFilename: "[name].chunk.js"\n\
+  },\n\
+  module: {\n\
+    loaders: [\n\
+      {test: /\.json$/, loader: "json-loader"},\n\
+    ]\n\
+  }\n\
+}, jester.MINIMAL_REQUIRED_CONFIG);\n\
+//console.log(module.exports); //to see the config that is used.\n';
 
 var defaultReadme = "# README \n\
   \n\

--- a/src/bin/jester-init.js
+++ b/src/bin/jester-init.js
@@ -4,7 +4,7 @@
 var fs = require("fs"),
     p = require("path");
 
-var FEATURES_PATH = "features/"
+var FEATURES_PATH = "features/";
 
 var defaultConf = {
     eslintRulesDir: "./eslint-rules/",

--- a/src/bin/jester-watch.js
+++ b/src/bin/jester-watch.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 "use strict";
+/*eslint no-process-exit: 0*/
 
 var loadConfig = require("../lib/loadConfig"),
     lint = require("../lib/lint"),
@@ -69,7 +70,7 @@ function startWatching() {
             },
             change: function (changeType, filePath, fileCurrentStat, filePreviousStat) {
                 try {
-                    if (filePath == config.configLocation) {
+                    if (filePath === config.configLocation) {
                         config = loadConfig();
                     }
 

--- a/src/bin/jester-watch.js
+++ b/src/bin/jester-watch.js
@@ -65,7 +65,7 @@ function startWatching() {
                     }
 
                     if (filePath.length > 3 && filePath.substr(-3) === ".js") {
-                        var build = rebuildProject(config.webpackOptions, config.fullEntryGlob, config.artifactPath, config.webpackWarningFilters);
+                        var build = rebuildProject(config.webpackOptions, config.fullEntryGlob, config.webpackWarningFilters);
                         if (isReallyFileChangeEvent(changeType, fileCurrentStat, filePreviousStat)) {
                             when.join(build, runTests(filePath)).done(function(){});
                         } else {

--- a/src/bin/jester-watch.js
+++ b/src/bin/jester-watch.js
@@ -9,26 +9,11 @@ var loadConfig = require("../lib/loadConfig"),
     KarmaServer = require("../lib/karmaServer"),
     createTestFile = require("../lib/createTestFile"),
     when = require('when'),
-    watchr = require('watchr');
+    watchr = require('watchr'),
+    getTestFileNameForPath = require("../lib/testFileHelpers").getTestFileNameForPath;
 
 var config = loadConfig();
 var server = new KarmaServer(config.karmaPath, config.karmaOptions);
-
-function getTestFileNameForPath(path) {
-    var result = "";
-    if (path.length > 8 && path.substr(-8) === ".test.js") {
-        result = path;
-    }
-    else if (path.length > 3 && path.substr(-3) === ".js") {
-        var testfile = path.substr(0, path.length - 3) + ".test.js";
-
-        if (require("fs").existsSync(testfile)) {
-            result = testfile;
-        }
-    }
-
-    return result;
-}
 
 function runTests(path) {
     return lint.lintFile(path, config.eslintRulesDir)

--- a/src/bin/jester-watch.js
+++ b/src/bin/jester-watch.js
@@ -65,7 +65,7 @@ function startWatching() {
                     }
 
                     if (filePath.length > 3 && filePath.substr(-3) === ".js") {
-                        var build = rebuildProject(config.webpackOptions, config.fullEntryGlob, config.webpackWarningFilters);
+                        var build = rebuildProject(config.webpackOptions, config.webpackWarningFilters);
                         if (isReallyFileChangeEvent(changeType, fileCurrentStat, filePreviousStat)) {
                             when.join(build, runTests(filePath)).done(function(){});
                         } else {

--- a/src/bin/jester-watch.js
+++ b/src/bin/jester-watch.js
@@ -42,7 +42,7 @@ function runTests(path) {
                     console.log("No tests found for '" + path + "'");
                     return false;
                 }
-                return createTestFile(testFile, config.karmaPath, config.webpackWarningFilters).then(function () {
+                return createTestFile(testFile, config.webpackOptions, config.karmaPath, config.webpackWarningFilters).then(function () {
                     return server.run();
                 });
             });
@@ -74,7 +74,7 @@ function startWatching() {
                     }
 
                     if (filePath.length > 3 && filePath.substr(-3) === ".js") {
-                        var build = rebuildProject(config.fullEntryGlob, config.artifactPath, config.webpackWarningFilters);
+                        var build = rebuildProject(config.webpackOptions, config.fullEntryGlob, config.artifactPath, config.webpackWarningFilters);
                         if (isReallyFileChangeEvent(changeType, fileCurrentStat, filePreviousStat)) {
                             when.join(build, runTests(filePath)).done(function(){});
                         } else {

--- a/src/bin/jester-watch.js
+++ b/src/bin/jester-watch.js
@@ -10,7 +10,7 @@ var loadConfig = require("../lib/loadConfig"),
     createTestFile = require("../lib/createTestFile"),
     when = require('when'),
     watchr = require('watchr'),
-    getTestFileNameForPath = require("../lib/testFileHelpers").getTestFileNameForPath;
+    getTestFileNamesForPath = require("../lib/testFileHelpers").getTestFileNamesForPath;
 
 var config = loadConfig();
 var server = new KarmaServer(config.karmaPath, config.karmaOptions);
@@ -22,13 +22,16 @@ function runTests(path) {
                 return false;
             }
 
-            return clearDir(config.karmaPath).then(function() {
-                var testFile = getTestFileNameForPath(path);
-                if (!testFile) {
+            return clearDir(config.karmaPath)
+            .then(function() {
+                return getTestFileNamesForPath(path);
+            })
+            .then(function (testFiles){
+                if (!testFiles.length === 0) {
                     console.log("No tests found for '" + path + "'");
                     return false;
                 }
-                return createTestFile(testFile, config.srcPath, config.webpackOptions, config.karmaPath, config.webpackWarningFilters).then(function () {
+                return createTestFile(testFiles, config.srcPath, config.webpackOptions, config.karmaPath, config.webpackWarningFilters).then(function () {
                     return server.run();
                 });
             });

--- a/src/bin/jester-watch.js
+++ b/src/bin/jester-watch.js
@@ -43,7 +43,7 @@ function runTests(path) {
                     console.log("No tests found for '" + path + "'");
                     return false;
                 }
-                return createTestFile(testFile, config.webpackOptions, config.karmaPath, config.webpackWarningFilters).then(function () {
+                return createTestFile(testFile, config.srcPath, config.webpackOptions, config.karmaPath, config.webpackWarningFilters).then(function () {
                     return server.run();
                 });
             });

--- a/src/bin/jester-watch.js
+++ b/src/bin/jester-watch.js
@@ -2,6 +2,8 @@
 "use strict";
 /*eslint no-process-exit: 0*/
 
+require("../lib/addProjectDirToSearchPath");
+
 var loadConfig = require("../lib/loadConfig"),
     lint = require("../lib/lint"),
     clearDir = require("../lib/clearDir"),

--- a/src/bin/jester-watch.js
+++ b/src/bin/jester-watch.js
@@ -30,7 +30,7 @@ function getTestFileNameForPath(path) {
 }
 
 function runTests(path) {
-    return lint.lintFile(path, config.eslintRules)
+    return lint.lintFile(path, config.eslintRulesDir)
         .then(function(lintSucceeded) {
             if(!lintSucceeded) {
                 return false;

--- a/src/bin/jester-watch.js
+++ b/src/bin/jester-watch.js
@@ -10,7 +10,7 @@ var loadConfig = require("../lib/loadConfig"),
     when = require('when'),
     watchr = require('watchr');
 
-var config = loadConfig("./jester.json");
+var config = loadConfig();
 var server = new KarmaServer(config.karmaPath, config.karmaOptions);
 
 function getTestFileNameForPath(path) {
@@ -69,8 +69,8 @@ function startWatching() {
             },
             change: function (changeType, filePath, fileCurrentStat, filePreviousStat) {
                 try {
-                    if (filePath == "jester.json") {
-                        config = loadConfig("./jester.json");
+                    if (filePath == config.configLocation) {
+                        config = loadConfig();
                     }
 
                     if (filePath.length > 3 && filePath.substr(-3) === ".js") {

--- a/src/injectable.js
+++ b/src/injectable.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function injectable(src) {
     this.cacheable();
     return "module.exports = function (injects) {\nvar module = {exports: {}};" + src.replace(/require\(([^\)]+)\)/g, "injects[$1]") + " return module.exports;\n}";

--- a/src/lib/addProjectDirToSearchPath.js
+++ b/src/lib/addProjectDirToSearchPath.js
@@ -1,0 +1,13 @@
+"use strict";
+var path = require("path");
+var Module = require('module').Module;
+var old_nodeModulePaths = Module._nodeModulePaths;
+
+Module._nodeModulePaths = function (from) {
+    var paths = 
+        old_nodeModulePaths.call(this, from)
+        .concat([
+            path.resolve(path.join(".", "node_modules"))
+        ]);
+    return paths;
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var config = require("./loadConfig");
+
+module.exports.injectable = require("../injectable");
+module.exports.MINIMAL_REQUIRED_CONFIG = {
+  output: {
+    path: config.artifactPath
+  },
+  devtool: "#source-map"
+};
+module.exports.deepMergeForWebpack = require("deepmerge");

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,12 +1,7 @@
 "use strict";
 
-var config = require("./loadConfig");
-
 module.exports.injectable = require("../injectable");
 module.exports.MINIMAL_REQUIRED_CONFIG = {
-  output: {
-    path: config.artifactPath
-  },
   devtool: "#source-map"
 };
 module.exports.deepMergeForWebpack = require("deepmerge");

--- a/src/lib/clearDir.js
+++ b/src/lib/clearDir.js
@@ -1,3 +1,4 @@
+"use strict";
 var glob = require("../lib/globPromise");
 var when = require("when");
 var node = require("when/node");

--- a/src/lib/createTestFile.js
+++ b/src/lib/createTestFile.js
@@ -20,6 +20,9 @@ function createEntryModules(srcPath, filenames) {
 }
 
 module.exports = function createTestFile(filenames, srcPath, webpackConfig, karmaPath, webpackWarningFilters) {
+    if (Array.isArray(webpackConfig)) {
+        webpackConfig = webpackConfig[0]; //always use the first config as the testfile config
+    }
     var config = Object.create(webpackConfig);
     config.output = Object.create(webpackConfig.output);
     config.output.path = karmaPath;

--- a/src/lib/createTestFile.js
+++ b/src/lib/createTestFile.js
@@ -16,20 +16,16 @@ function createEntryModules(filenames) {
     return entryModules;
 }
 
-module.exports = function createTestFile(filenames, karmaPath, webpackWarningFilters) {
-    return webpack({
-        entry: createEntryModules(filenames),
-        output: {
-            path: karmaPath,
-            filename: "[name].js"
-        },
-        module: {
-            loaders: [
-                {test: /\.json$/, loader: require.resolve("json-loader")}
-            ]
-        },
-        devtool: "#source-map"
-    }).then(function(stats) {
+module.exports = function createTestFile(filenames, webpackConfig, karmaPath, webpackWarningFilters) {
+    var config = Object.create(webpackConfig);
+    config.entry = createEntryModules(filenames);
+    if (config.output){
+        config.output = Object.create(config.output);
+    } else {
+        config.output = {};
+    }
+    config.output.path = karmaPath;
+    return webpack(config).then(function(stats) {
         return handleWebpackResult(stats, webpackWarningFilters);
     });
 };

--- a/src/lib/createTestFile.js
+++ b/src/lib/createTestFile.js
@@ -4,7 +4,7 @@ var webpack = require("./webpackPromise"),
     p = require("path"),
     stripTestExtensions = require("./testFileHelpers").stripTestExtensions;
 
-function createEntryModules(karmaPath, srcPath, filenames) {
+function createEntryModules(srcPath, filenames) {
     var entryModules = {};
     if (typeof filenames === "string") {
         filenames = [filenames];
@@ -12,7 +12,7 @@ function createEntryModules(karmaPath, srcPath, filenames) {
 
     filenames.forEach(function(file) {
         var featurename = require("path").relative(srcPath, stripTestExtensions(file)).replace(/\//g, "_");
-        entryModules[p.join(karmaPath, featurename)] = file;
+        entryModules[featurename] = file;
         console.log("    * " + featurename + " (" + file + ")." );
     });
 
@@ -21,7 +21,9 @@ function createEntryModules(karmaPath, srcPath, filenames) {
 
 module.exports = function createTestFile(filenames, srcPath, webpackConfig, karmaPath, webpackWarningFilters) {
     var config = Object.create(webpackConfig);
-    config.entry = createEntryModules(karmaPath, srcPath, filenames);
+    config.output = Object.create(webpackConfig.output);
+    config.output.path = karmaPath;
+    config.entry = createEntryModules(srcPath, filenames);//fixme output may be null
     config.output = Object.create(config.output || {});
     config.output.filename = "[name].karmatest.js";
     return webpack(config).then(function(stats) {

--- a/src/lib/createTestFile.js
+++ b/src/lib/createTestFile.js
@@ -1,7 +1,8 @@
 "use strict";
 var webpack = require("./webpackPromise"),
     handleWebpackResult = require("./handleWebpackResult"),
-    p = require("path");
+    p = require("path"),
+    stripTestExtensions = require("./testFileHelpers").stripTestExtensions;
 
 function createEntryModules(karmaPath, srcPath, filenames) {
     var entryModules = {};
@@ -10,7 +11,7 @@ function createEntryModules(karmaPath, srcPath, filenames) {
     }
 
     filenames.forEach(function(file) {
-        var featurename = require("path").relative(srcPath, file.substr(0, file.length - 8)).replace(/\//g, "_");
+        var featurename = require("path").relative(srcPath, stripTestExtensions(file)).replace(/\//g, "_");
         entryModules[p.join(karmaPath, featurename)] = file;
         console.log("    * " + featurename + " (" + file + ")." );
     });

--- a/src/lib/createTestFile.js
+++ b/src/lib/createTestFile.js
@@ -1,3 +1,4 @@
+"use strict";
 var webpack = require("./webpackPromise"),
     handleWebpackResult = require("./handleWebpackResult"),
     p = require("path");

--- a/src/lib/createTestFile.js
+++ b/src/lib/createTestFile.js
@@ -1,7 +1,8 @@
 var webpack = require("./webpackPromise"),
-    handleWebpackResult = require("./handleWebpackResult");
+    handleWebpackResult = require("./handleWebpackResult"),
+    p = require("path");
 
-function createEntryModules(filenames) {
+function createEntryModules(karmaPath, filenames) {
     var entryModules = {};
     if (typeof filenames === "string") {
         filenames = [filenames];
@@ -9,7 +10,7 @@ function createEntryModules(filenames) {
 
     filenames.forEach(function(file) {
         var featurename = require("path").basename(file.substr(0, file.length - 8));
-        entryModules[featurename] = file;
+        entryModules[p.join(karmaPath, featurename)] = file;
         console.log("    * " + featurename + " (" + file + ")." );
     });
 
@@ -18,13 +19,7 @@ function createEntryModules(filenames) {
 
 module.exports = function createTestFile(filenames, webpackConfig, karmaPath, webpackWarningFilters) {
     var config = Object.create(webpackConfig);
-    config.entry = createEntryModules(filenames);
-    if (config.output){
-        config.output = Object.create(config.output);
-    } else {
-        config.output = {};
-    }
-    config.output.path = karmaPath;
+    config.entry = createEntryModules(karmaPath, filenames);
     return webpack(config).then(function(stats) {
         return handleWebpackResult(stats, webpackWarningFilters);
     });

--- a/src/lib/createTestFile.js
+++ b/src/lib/createTestFile.js
@@ -3,14 +3,14 @@ var webpack = require("./webpackPromise"),
     handleWebpackResult = require("./handleWebpackResult"),
     p = require("path");
 
-function createEntryModules(karmaPath, filenames) {
+function createEntryModules(karmaPath, srcPath, filenames) {
     var entryModules = {};
     if (typeof filenames === "string") {
         filenames = [filenames];
     }
 
     filenames.forEach(function(file) {
-        var featurename = require("path").basename(file.substr(0, file.length - 8));
+        var featurename = require("path").relative(srcPath, file.substr(0, file.length - 8)).replace(/\//g, "_");
         entryModules[p.join(karmaPath, featurename)] = file;
         console.log("    * " + featurename + " (" + file + ")." );
     });
@@ -18,9 +18,11 @@ function createEntryModules(karmaPath, filenames) {
     return entryModules;
 }
 
-module.exports = function createTestFile(filenames, webpackConfig, karmaPath, webpackWarningFilters) {
+module.exports = function createTestFile(filenames, srcPath, webpackConfig, karmaPath, webpackWarningFilters) {
     var config = Object.create(webpackConfig);
-    config.entry = createEntryModules(karmaPath, filenames);
+    config.entry = createEntryModules(karmaPath, srcPath, filenames);
+    config.output = Object.create(config.output || {});
+    config.output.filename = "[name].karmatest.js";
     return webpack(config).then(function(stats) {
         return handleWebpackResult(stats, webpackWarningFilters);
     });

--- a/src/lib/createTestFile.js
+++ b/src/lib/createTestFile.js
@@ -11,7 +11,7 @@ function createEntryModules(srcPath, filenames) {
     }
 
     filenames.forEach(function(file) {
-        var featurename = require("path").relative(srcPath, stripTestExtensions(file)).replace(/\//g, "_");
+        var featurename = require("path").relative(srcPath, stripTestExtensions(file)).replace(new RegExp("\\" + p.sep, "g"), "_");
         entryModules[featurename] = file;
         console.log("    * " + featurename + " (" + file + ")." );
     });

--- a/src/lib/globPromise.js
+++ b/src/lib/globPromise.js
@@ -1,3 +1,4 @@
+"use strict";
 var glob = require("glob");
 var when = require("when");
 

--- a/src/lib/karmaServer.js
+++ b/src/lib/karmaServer.js
@@ -15,8 +15,6 @@ function KarmaServer(karmaPath, options) {
         frameworks: ["jasmine"].concat(options.frameworks || []),
         files: [
             "../polyfills/*.js",
-            {pattern: require.resolve("source-map-support/browser-source-map-support"), watched: false, included: true},
-            {pattern: require.resolve("./loadSourcemapsupport"), watched: false, included: true},
             {pattern: '*.js.map', watched: false, included: false, served: true},
             "*.karmatest.js",
             {pattern: '*.js', watched: true, included: false, served: true}

--- a/src/lib/karmaServer.js
+++ b/src/lib/karmaServer.js
@@ -14,6 +14,7 @@ function KarmaServer(karmaPath, options) {
         basePath: karmaPath,
         frameworks: ["jasmine"].concat(options.frameworks || []),
         files: [
+            "../polyfills/*.js",
             {pattern: require.resolve("source-map-support/browser-source-map-support"), watched: false, included: true},
             {pattern: require.resolve("./loadSourcemapsupport"), watched: false, included: true},
             {pattern: '*.js.map', watched: false, included: false, served: true},

--- a/src/lib/karmaServer.js
+++ b/src/lib/karmaServer.js
@@ -18,7 +18,8 @@ function KarmaServer(karmaPath, options) {
             {pattern: require.resolve("source-map-support/browser-source-map-support"), watched: false, included: true},
             {pattern: require.resolve("./loadSourcemapsupport"), watched: false, included: true},
             {pattern: '*.js.map', watched: false, included: false, served: true},
-            "*.js"
+            "*.karmatest.js",
+            {pattern: '*.js', watched: true, included: false, served: true}
         ],
         proxies: options.proxies || {},
         preprocessors: options.preprocessors || {},

--- a/src/lib/karmaServer.js
+++ b/src/lib/karmaServer.js
@@ -1,3 +1,4 @@
+"use strict";
 var when = require("when"),
     karma = require("karma");
 

--- a/src/lib/lint.js
+++ b/src/lib/lint.js
@@ -1,67 +1,58 @@
-var eslint = require("eslint").linter,
+"use strict";
+var CLIEngine = require("eslint").CLIEngine,
     formatter = require("eslint-path-formatter"),
     glob = require("./globPromise"),
-    p = require("path"),
-    readFile = require("fs").readFile,
-    rulesLoader = require("eslint/lib/rules"),
+    existsSync = require("fs").existsSync,
     when = require("when");
 
-rulesLoader.load(p.resolve("./eslint-rules"));
-rulesLoader.load(p.join(__dirname, "../eslint-rules"));
 
-function lintFile(filename, rules) {
+function lintFile(filename, eslintRulesDir) {
     return when.promise(function (resolve, reject, notify) {
-        readFile(filename, {encoding: "utf8"}, function (err, file) {
-            if (err) {
-                reject(err);
-            } else {
-                //Jslint doesn't get an env or globals. Specify globals in the source files like so:
-                // /*globals document:false, window: false*/
-                var globals = {
-                    "require": true,
-                    "module": true,
-                    "console": true
-                };
-                if (filename.substr(-8) === ".test.js") {
-                    globals["describe"] = true;
-                    globals["it"] = true;
-                    globals["expect"] = true;
+        var rulePaths;
+        if (existsSync(eslintRulesDir)) {
+            rulePaths = [ eslintRulesDir ];
+        } else {
+            rulePaths = [];
+        }
+        var opts = {
+            rulePaths: rulePaths
+        };
+        if (filename.substr(-8) === ".test.js") {
+            opts.envs = ["jasmine"];
+        }
+        var eslint = new CLIEngine(opts);
+
+        if (eslint.isPathIgnored(filename)) {
+            console.log(filename + ":");
+            console.log(" [ignored by eslint. Check .eslintignore files]");
+            resolve(true);
+        } else {
+            var results = eslint.executeOnFiles([filename]).results;
+
+            if (results) {
+                var lintSucceeded =
+                    !results.some(function (result) {
+                        return result.messages.some(function(eslintMessage) {
+                            return eslintMessage.fatal || // parse error, or:
+                                eslintMessage.severity === 2; // lint error
+                        });
+                    });
+                if (results.some(function(result) { return result.messages.length > 0; })) {
+                    console.log(formatter(results));
                 }
-                var config = {
-                    rules: rules,
-                    globals: globals
-                };
-
-                var result = eslint.verify(file, config);
-
-                var hasError = function(eslintMessage) {
-                    return eslintMessage.fatal || // parse error, or:
-                        (rules[eslintMessage.ruleId][0] || rules[eslintMessage.ruleId]) === 2; // lint error
-                };
-
-                var lintSucceeded = true;
-
-                if (result && result.length > 0) {
-                    lintSucceeded = !result.some(hasError);
-
-                    console.log(filename + ":");
-                    console.log(formatter([{
-                        messages: result,
-                        filePath: filename
-                    }], config));
-                }
-
                 resolve(lintSucceeded);
+            } else {
+                reject("Eslint returned no results!");
             }
-        });
+        }
     });
-};
+}
 
-function lintGlob(globPattern, rules) {
+function lintGlob(globPattern, eslintRulesDir) {
     return glob(globPattern).then(function (jsFiles) {
         console.log("Linting ", jsFiles.length, " file" + (jsFiles.length === 1 ? "" : "s") + ".");
         return when.map(jsFiles, function (file) {
-            return lintFile(file, rules);
+            return lintFile(file, eslintRulesDir);
         }).then(function(values) {
             return values.every(function(x) { return x; });
         });

--- a/src/lib/lint.js
+++ b/src/lib/lint.js
@@ -3,7 +3,8 @@ var CLIEngine = require("eslint").CLIEngine,
     formatter = require("eslint-path-formatter"),
     glob = require("./globPromise"),
     existsSync = require("fs").existsSync,
-    when = require("when");
+    when = require("when"),
+    isTestFile = require("./testFileHelpers").isTestFile;
 
 
 function lintFile(filename, eslintRulesDir) {
@@ -17,7 +18,7 @@ function lintFile(filename, eslintRulesDir) {
         var opts = {
             rulePaths: rulePaths
         };
-        if (filename.substr(-8) === ".test.js") {
+        if (isTestFile(filename)) {
             opts.envs = ["jasmine"];
         }
         var eslint = new CLIEngine(opts);

--- a/src/lib/loadConfig.js
+++ b/src/lib/loadConfig.js
@@ -9,7 +9,6 @@ module.exports = function loadConfig() {
     config.eslintRulesDir = p.resolve(config.eslintRulesDir);
     config.srcPath = p.resolve(config.srcPath);
     config.karmaPath = p.resolve(config.karmaPath);
-    config.artifactPath = p.resolve(config.artifactPath);
     config.fullEntryGlob = require("path").join(config.srcPath, config.entryGlob);
     config.webpackOptions = require(p.resolve("webpack.config.js"));
     config.configLocation = CONFIG_LOCATION;

--- a/src/lib/loadConfig.js
+++ b/src/lib/loadConfig.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var p = require("path");
 var CONFIG_LOCATION = "./jester.json";
 

--- a/src/lib/loadConfig.js
+++ b/src/lib/loadConfig.js
@@ -9,7 +9,6 @@ module.exports = function loadConfig() {
     config.eslintRulesDir = p.resolve(config.eslintRulesDir);
     config.srcPath = p.resolve(config.srcPath);
     config.karmaPath = p.resolve(config.karmaPath);
-    config.fullEntryGlob = require("path").join(config.srcPath, config.entryGlob);
     config.webpackOptions = require(p.resolve("webpack.config.js"));
     config.configLocation = CONFIG_LOCATION;
     return config;

--- a/src/lib/loadConfig.js
+++ b/src/lib/loadConfig.js
@@ -8,5 +8,6 @@ module.exports = function loadConfig(configLocation) {
     config.karmaPath = p.resolve(config.karmaPath);
     config.artifactPath = p.resolve(config.artifactPath);
     config.fullEntryGlob = require("path").join(config.srcPath, config.entryGlob);
+    config.webpackOptions = require(p.resolve("webpack.config.js"));
     return config;
 };

--- a/src/lib/loadConfig.js
+++ b/src/lib/loadConfig.js
@@ -1,7 +1,8 @@
 var p = require("path");
+var CONFIG_LOCATION = "./jester.json";
 
-module.exports = function loadConfig(configLocation) {
-    var contents = require("fs").readFileSync(configLocation, {encoding: "utf8"});
+module.exports = function loadConfig() {
+    var contents = require("fs").readFileSync(CONFIG_LOCATION, {encoding: "utf8"});
     var config = JSON.parse(contents);
     config.eslintRulesDir = p.resolve(config.eslintRulesDir);
     config.srcPath = p.resolve(config.srcPath);
@@ -9,5 +10,6 @@ module.exports = function loadConfig(configLocation) {
     config.artifactPath = p.resolve(config.artifactPath);
     config.fullEntryGlob = require("path").join(config.srcPath, config.entryGlob);
     config.webpackOptions = require(p.resolve("webpack.config.js"));
+    config.configLocation = CONFIG_LOCATION;
     return config;
 };

--- a/src/lib/loadSourcemapsupport.js
+++ b/src/lib/loadSourcemapsupport.js
@@ -1,4 +1,0 @@
-/*global sourceMapSupport*/
-"use strict";
-
-sourceMapSupport.install();

--- a/src/lib/loadSourcemapsupport.js
+++ b/src/lib/loadSourcemapsupport.js
@@ -1,1 +1,4 @@
+/*global sourceMapSupport*/
+"use strict";
+
 sourceMapSupport.install();

--- a/src/lib/rebuildDocumentation.js
+++ b/src/lib/rebuildDocumentation.js
@@ -1,4 +1,5 @@
-var child_process = require("child_process"),
+"use strict";
+var childProcess = require("child_process"),
     p = require("path"),
     fs = require("fs"),
     when = require("when");
@@ -33,7 +34,7 @@ module.exports = function rebuildDocumentation(srcPath, targetPath, confPath, re
             .concat(target)
             .concat(conf);
 
-        var process = child_process.fork(jsdoc, args);
+        var process = childProcess.fork(jsdoc, args);
 
         process.on('close', function (code) {
             if (code === 0) {
@@ -41,7 +42,7 @@ module.exports = function rebuildDocumentation(srcPath, targetPath, confPath, re
                 resolve();
             } else {
                 console.error("jsdoc failed! (exit code " + code + "). '" + jsdoc + "' was called with the following arguments:");
-                console.error(args.map(function (arg, i) { return " " + i + ": " + arg}).join("\n"));
+                console.error(args.map(function (arg, i) { return " " + i + ": " + arg; }).join("\n"));
                 reject();
             }
         });

--- a/src/lib/rebuildProject.js
+++ b/src/lib/rebuildProject.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var glob = require("../lib/globPromise"),
     webpack = require("../lib/webpackPromise"),
     clearDir = require("./clearDir"),

--- a/src/lib/rebuildProject.js
+++ b/src/lib/rebuildProject.js
@@ -1,30 +1,11 @@
 "use strict";
 
-var glob = require("../lib/globPromise"),
-    webpack = require("../lib/webpackPromise"),
-    clearDir = require("./clearDir"),
-    handleWebpackResult = require("./handleWebpackResult"),
-    p = require("path");
+var webpack = require("../lib/webpackPromise"),
+    handleWebpackResult = require("./handleWebpackResult");
 
-function createEntryModules(featureFiles) {
-    var entryModules = {};
-
-    featureFiles.forEach(function (file) {
-        var featurename = p.basename(p.dirname(file));
-        entryModules[featurename] = file;
-        console.log("    * " + featurename + " (" + file + ")." );
-    });
-
-    return entryModules;
-}
-
-module.exports = function rebuildProject(webpackConfig, entryGlob, webpackWarningFilters) {
-    return glob(entryGlob)
-        .then(function (featureFiles) {
-            var config = Object.create(webpackConfig);
-            config.entry = createEntryModules(featureFiles);
-            return webpack(config);
-        })
+module.exports = function rebuildProject(webpackConfig, webpackWarningFilters) {
+        var config = Object.create(webpackConfig);
+        return webpack(config)
         .then(function (stats){
             return handleWebpackResult(stats, webpackWarningFilters);
         });

--- a/src/lib/rebuildProject.js
+++ b/src/lib/rebuildProject.js
@@ -4,12 +4,12 @@ var glob = require("../lib/globPromise"),
     handleWebpackResult = require("./handleWebpackResult"),
     p = require("path");
 
-function createEntryModules(featureFiles) {
+function createEntryModules(artifactPath, featureFiles) {
     var entryModules = {};
 
     featureFiles.forEach(function (file) {
         var featurename = p.basename(p.dirname(file));
-        entryModules[featurename] = file;
+        entryModules[p.join(artifactPath, featurename)] = file;
         console.log("    * " + featurename + " (" + file + ")." );
     });
 
@@ -23,13 +23,7 @@ module.exports = function rebuildProject(webpackConfig, entryGlob, artifactPath,
         })
         .then(function (featureFiles) {
             var config = Object.create(webpackConfig);
-            config.entry = createEntryModules(featureFiles);
-            if (config.output){
-              config.output = Object.create(config.output);
-            } else {
-              config.output = {};
-            }
-            config.output.path = artifactPath;
+            config.entry = createEntryModules(artifactPath, featureFiles);
             return webpack(config);
         })
         .then(function (stats){

--- a/src/lib/rebuildProject.js
+++ b/src/lib/rebuildProject.js
@@ -6,26 +6,23 @@ var glob = require("../lib/globPromise"),
     handleWebpackResult = require("./handleWebpackResult"),
     p = require("path");
 
-function createEntryModules(artifactPath, featureFiles) {
+function createEntryModules(featureFiles) {
     var entryModules = {};
 
     featureFiles.forEach(function (file) {
         var featurename = p.basename(p.dirname(file));
-        entryModules[p.join(artifactPath, featurename)] = file;
+        entryModules[featurename] = file;
         console.log("    * " + featurename + " (" + file + ")." );
     });
 
     return entryModules;
 }
 
-module.exports = function rebuildProject(webpackConfig, entryGlob, artifactPath, webpackWarningFilters) {
-    return clearDir(artifactPath)
-        .then(function filesCleared() {
-            return glob(entryGlob);
-        })
+module.exports = function rebuildProject(webpackConfig, entryGlob, webpackWarningFilters) {
+    return glob(entryGlob)
         .then(function (featureFiles) {
             var config = Object.create(webpackConfig);
-            config.entry = createEntryModules(artifactPath, featureFiles);
+            config.entry = createEntryModules(featureFiles);
             return webpack(config);
         })
         .then(function (stats){

--- a/src/lib/rebuildProject.js
+++ b/src/lib/rebuildProject.js
@@ -4,8 +4,7 @@ var webpack = require("../lib/webpackPromise"),
     handleWebpackResult = require("./handleWebpackResult");
 
 module.exports = function rebuildProject(webpackConfig, webpackWarningFilters) {
-        var config = Object.create(webpackConfig);
-        return webpack(config)
+    return webpack(webpackConfig)
         .then(function (stats){
             return handleWebpackResult(stats, webpackWarningFilters);
         });

--- a/src/lib/runAllTests.js
+++ b/src/lib/runAllTests.js
@@ -4,7 +4,7 @@ var lint = require("../lib/lint"),
     clearDir = require("../lib/clearDir"),
     KarmaServer = require("../lib/karmaServer"),
     createTestFile = require("../lib/createTestFile"),
-    glob = require("../lib/globPromise");
+    getTestFiles = require("../lib/testFileHelpers").getTestFiles;
 
 module.exports = function runAllTests(config) {
     var sources = config.srcPath + "/**/*.js";
@@ -13,8 +13,8 @@ module.exports = function runAllTests(config) {
         .then(function(hasLintSucceeded) {
 
             return clearDir(config.karmaPath)
-                .then(function() {
-                    return glob(config.srcPath + "/**/*.test.js");
+                .then(function () {
+                    return getTestFiles(config.srcPath);
                 })
                 .then(function (testInputFiles) {
                     return createTestFile(testInputFiles, config.srcPath, config.webpackOptions, config.karmaPath, config.webpackWarningFilters);

--- a/src/lib/runAllTests.js
+++ b/src/lib/runAllTests.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var lint = require("../lib/lint"),
     clearDir = require("../lib/clearDir"),
     KarmaServer = require("../lib/karmaServer"),

--- a/src/lib/runAllTests.js
+++ b/src/lib/runAllTests.js
@@ -15,7 +15,7 @@ module.exports = function runAllTests(config) {
                     return glob(config.srcPath + "/**/*.test.js");
                 })
                 .then(function (testInputFiles) {
-                    return createTestFile(testInputFiles, config.karmaPath, config.webpackWarningFilters);
+                    return createTestFile(testInputFiles, config.webpackOptions, config.karmaPath, config.webpackWarningFilters);
                 })
                 .catch(function(err) {
                     console.error("failed creating test files ", err);

--- a/src/lib/runAllTests.js
+++ b/src/lib/runAllTests.js
@@ -17,7 +17,7 @@ module.exports = function runAllTests(config) {
                     return glob(config.srcPath + "/**/*.test.js");
                 })
                 .then(function (testInputFiles) {
-                    return createTestFile(testInputFiles, config.webpackOptions, config.karmaPath, config.webpackWarningFilters);
+                    return createTestFile(testInputFiles, config.srcPath, config.webpackOptions, config.karmaPath, config.webpackWarningFilters);
                 })
                 .catch(function(err) {
                     console.error("failed creating test files ", err);

--- a/src/lib/runAllTests.js
+++ b/src/lib/runAllTests.js
@@ -7,7 +7,7 @@ var lint = require("../lib/lint"),
 module.exports = function runAllTests(config) {
     var sources = config.srcPath + "/**/*.js";
 
-    return lint.lintGlob(sources, config.eslintRules)
+    return lint.lintGlob(sources, config.eslintRulesDir)
         .then(function(hasLintSucceeded) {
 
             return clearDir(config.karmaPath)

--- a/src/lib/testFileHelpers.js
+++ b/src/lib/testFileHelpers.js
@@ -1,0 +1,36 @@
+"use strict";
+var glob = require("../lib/globPromise");
+
+function stripTestExtensions(filename) {
+    return filename.substr(0, filename.length - 8);
+}
+
+
+function isTestFile(filename) {
+    return filename.substr(-8) === ".test.js";
+}
+
+function getTestFileNameForPath(path) {
+    var result = "";
+    if (path.length > 8 && path.substr(-8) === ".test.js") {
+        result = path;
+    }
+    else if (path.length > 3 && path.substr(-3) === ".js") {
+        var testfile = path.substr(0, path.length - 3) + ".test.js";
+
+        if (require("fs").existsSync(testfile)) {
+            result = testfile;
+        }
+    }
+
+    return result;
+}
+
+function getTestFiles(path) {
+    return glob(path + "/**/*.test.js");
+}
+
+module.exports.stripTestExtensions = stripTestExtensions;
+module.exports.isTestFile = isTestFile;
+module.exports.getTestFileNameForPath = getTestFileNameForPath;
+module.exports.getTestFiles = getTestFiles;

--- a/src/lib/testFileHelpers.js
+++ b/src/lib/testFileHelpers.js
@@ -8,32 +8,48 @@ var jsSuffix = ".js";
 var testSuffix = ".test" + jsSuffix;
 
 function stripTestExtensions(filename) {
-    return filename.substr(0, filename.length - testSuffix.length);
+    if (isTestFile(filename)) {
+      return filename.substr(0, filename.length - testSuffix.length);
+    } else {
+      return filename;
+    }
 }
 
+function stripJsExtensions(filename) {
+    if (isJsFile(filename)) {
+      return filename.substr(0, filename.length - jsSuffix.length);
+    } else {
+      return filename;
+    }
+}
+
+function endsWith(str, substr) {
+    return str !== substr && str.substr(-substr.length) === substr;
+}
 
 function isTestFile(filename) {
-    return filename.substr(-testSuffix.length) === ".test.js";
+    return endsWith(filename, testSuffix);
+}
+
+function isJsFile(filename) {
+    return endsWith(filename, jsSuffix);
 }
 
 function getTestFileNameForPath(path) {
-    var result = "";
-    if (path.length > testSuffix.length && path.substr(-testSuffix.length) === ".test.js") {
-        result = path;
-    }
-    else if (path.length > jsSuffix.length && path.substr(-jsSuffix.length) === ".js") {
-        var testfile = path.substr(0, path.length - jsSuffix.length) + ".test.js";
-
+    if (isTestFile(path)) {
+        return path;
+    } else if (isJsFile(path)) {
+        var testfile = stripJsExtensions(path) + testSuffix;
         if (require("fs").existsSync(testfile)) {
-            result = testfile;
+            return testfile;
         }
+    } else {
+      return "";
     }
-
-    return result;
 }
 
 function getTestFiles(path) {
-    return glob(path + "/**/*.test.js");
+    return glob(path + "/**/*" + testSuffix);
 }
 
 module.exports.stripTestExtensions = stripTestExtensions;

--- a/src/lib/testFileHelpers.js
+++ b/src/lib/testFileHelpers.js
@@ -1,22 +1,28 @@
 "use strict";
 var glob = require("../lib/globPromise");
 
+//A file is called "fooBar_whatever.suffix.suffix.js"
+//the accompanying testfile is then called fooBar_whatever.suffix.suffix.test.js
+
+var jsSuffix = ".js";
+var testSuffix = ".test" + jsSuffix;
+
 function stripTestExtensions(filename) {
-    return filename.substr(0, filename.length - 8);
+    return filename.substr(0, filename.length - testSuffix.length);
 }
 
 
 function isTestFile(filename) {
-    return filename.substr(-8) === ".test.js";
+    return filename.substr(-testSuffix.length) === ".test.js";
 }
 
 function getTestFileNameForPath(path) {
     var result = "";
-    if (path.length > 8 && path.substr(-8) === ".test.js") {
+    if (path.length > testSuffix.length && path.substr(-testSuffix.length) === ".test.js") {
         result = path;
     }
-    else if (path.length > 3 && path.substr(-3) === ".js") {
-        var testfile = path.substr(0, path.length - 3) + ".test.js";
+    else if (path.length > jsSuffix.length && path.substr(-jsSuffix.length) === ".js") {
+        var testfile = path.substr(0, path.length - jsSuffix.length) + ".test.js";
 
         if (require("fs").existsSync(testfile)) {
             result = testfile;

--- a/src/lib/webpackPromise.js
+++ b/src/lib/webpackPromise.js
@@ -1,4 +1,6 @@
+"use strict";
+
 var node = require("when/node"),
     webpack = require("webpack");
 
-module.exports =  node.lift(webpack);
+module.exports = node.lift(webpack);

--- a/src/testing/withPermutations.js
+++ b/src/testing/withPermutations.js
@@ -1,3 +1,4 @@
+"use strict";
 /*globals console, setTimeout*/
 module.exports = function withPermutations(specFunc, cb) {
     var permutators = [];

--- a/src/testing/withPermutations.test.js
+++ b/src/testing/withPermutations.test.js
@@ -1,21 +1,22 @@
-/*global describe, it, expect, setTimeout*/
+/*eslint-env jasmine, browser*/
+"use strict";
 var withPermutations = require("./withPermutations");
 
 describe("permutator", function () {
     it("creates the permutations of the calls to permutate", function () {
         var results = [];
         withPermutations(function (permutate) {
-            results.push([permutate(1,2), permutate(3,4)]);
+            results.push([permutate(1, 2), permutate(3, 4)]);
         });
-        expect(results).toEqual([[1,3], [1,4], [2,3], [2,4]]);
+        expect(results).toEqual([[1, 3], [1, 4], [2, 3], [2, 4]]);
     });
     it("Can handle conditionally including more or less permutators", function () {
         var results = [];
         withPermutations(function (p) {
-            var x = p(1,6);
+            var x = p(1, 6);
             var y = 0;
             if (x > 2) {
-                y = p(3,4);
+                y = p(3, 4);
             }
             results.push([x, y]);
         });
@@ -24,7 +25,7 @@ describe("permutator", function () {
     it("Can handle including different permutators based on logic", function () {
         var results = [];
         withPermutations(function (p) {
-            var x = p(1,6);
+            var x = p(1, 6);
             var y;
             if (x < 2) {
                 y = p("a", "b");
@@ -41,37 +42,37 @@ describe("permutator (Edge cases)", function () {
     it("works if you provide only one argument to the last call", function () {
         var results = [];
         withPermutations(function (permutate) {
-            results.push([permutate(1,2), permutate(3)]);
+            results.push([permutate(1, 2), permutate(3)]);
         });
-        expect(results).toEqual([[1,3], [2,3]]);
+        expect(results).toEqual([[1, 3], [2, 3]]);
     });
     it("works if you provide only one argument to the first call", function () {
         var results = [];
         withPermutations(function (permutate) {
             results.push([permutate(1), permutate(2, 3)]);
         });
-        expect(results).toEqual([[1,2], [1,3]]);
+        expect(results).toEqual([[1, 2], [1, 3]]);
     });
     it("works if you provide only one argument to both calls", function () {
         var results = [];
         withPermutations(function (permutate) {
             results.push([permutate(1), permutate(3)]);
         });
-        expect(results).toEqual([[1,3]]);
+        expect(results).toEqual([[1, 3]]);
     });
     it("works async", function (testDone) {
         var results = [];
         var curPermutation = 0;
         withPermutations(function (permutate, done) {
-            var x = permutate(1,2);
+            var x = permutate(1, 2);
             setTimeout(function () {
-                var y = permutate(3,4);
+                var y = permutate(3, 4);
                 results.push([x, y]);
                 curPermutation++;
                 done();
             }, 0);
         }, function () {
-            expect(results).toEqual([[1,3], [1,4], [2,3], [2,4]]);
+            expect(results).toEqual([[1, 3], [1, 4], [2, 3], [2, 4]]);
             testDone();
         });
     });


### PR DESCRIPTION
- Update eslint (**breaking changes in eslint pragma's**)
- update webpack
- use .eslintrc instead of jester.json eslint config  (**breaking change**)
- use webpack.config instead of jester.json webpack config  (**breaking change**)
- karma can now load polyfills for you
- bugfixes
  - No longer overwriting test files with same basename in jester-batch
  - No longer running tests from .chunk.js files that webpack sometimes generates unless they're required from an entrypoint
- less precise matcher for finding the test file for a js file 
