### PR TITLE
Removing 'string' suffix on each error line.

### DIFF
--- a/src/lib/handleWebpackResult.js
+++ b/src/lib/handleWebpackResult.js
@@ -17,7 +17,7 @@ module.exports = function handleWebpackResult(stats, webpackWarningFilters) {
 
         var logErrorsByLine = function (errors) {
             byLine(errors, function (err) {
-                console.log("    ", err, typeof err);
+                console.log("    ", err);
             });
         };
 


### PR DESCRIPTION
This was introduced by commit 93f78302b06c4a8eb0a3e94cf183eddc137a714b and that was presumably unintentional.
