### PR TITLE
Made createEntryModules work on Windows (escape directory separator)

### DIFF
--- a/src/lib/createTestFile.js
+++ b/src/lib/createTestFile.js
@@ -11,7 +11,7 @@ function createEntryModules(srcPath, filenames) {
     }
 
     filenames.forEach(function(file) {
-        var featurename = require("path").relative(srcPath, stripTestExtensions(file)).replace(/\//g, "_");
+        var featurename = require("path").relative(srcPath, stripTestExtensions(file)).replace(new RegExp("\\" + p.sep, "g"), "_");
         entryModules[featurename] = file;
         console.log("    * " + featurename + " (" + file + ")." );
     });


### PR DESCRIPTION
Uses p.sep instead of a hardcoded regex so that replacing the path separator works on windows too.
